### PR TITLE
Fixing Vue TypeScript Compiler error

### DIFF
--- a/src/components/modals/ModalMove.vue
+++ b/src/components/modals/ModalMove.vue
@@ -52,12 +52,12 @@ export default {
 <script setup>
 import VFModalLayout from './ModalLayout.vue';
 import {inject, ref} from 'vue';
+import Message from '../Message.vue';
 
 const emitter = inject('emitter');
 const {t} = inject('i18n');
 const {getStore} = inject('storage');
 const adapter = inject('adapter');
-import Message from '../Message.vue';
 
 const props = defineProps({
   selection: Object,

--- a/src/components/modals/ModalNewFile.vue
+++ b/src/components/modals/ModalNewFile.vue
@@ -40,12 +40,12 @@ export default {
 <script setup>
 import VFModalLayout from './ModalLayout.vue';
 import {inject, ref} from 'vue';
+import Message from '../Message.vue';
 
 const emitter = inject('emitter');
 const {getStore} = inject('storage');
 const adapter = inject('adapter');
 const {t} = inject('i18n');
-import Message from '../Message.vue';
 
 const props = defineProps({
   selection: Object,

--- a/src/components/modals/ModalNewFolder.vue
+++ b/src/components/modals/ModalNewFolder.vue
@@ -37,11 +37,11 @@ export default {
 <script setup>
 import VFModalLayout from './ModalLayout.vue';
 import {inject, ref} from 'vue';
+import Message from '../Message.vue';
 
 const emitter = inject('emitter');
 const {getStore} = inject('storage');
 const adapter = inject('adapter');
-import Message from '../Message.vue';
 const {t} = inject('i18n');
 
 const props = defineProps({

--- a/src/components/modals/ModalUnarchive.vue
+++ b/src/components/modals/ModalUnarchive.vue
@@ -42,12 +42,12 @@ export default {
 <script setup>
 import VFModalLayout from './ModalLayout.vue';
 import {inject, ref} from 'vue';
+import Message from '../Message.vue';
 
 const emitter = inject('emitter');
 const {getStore} = inject('storage');
 const adapter = inject('adapter');
 const {t} = inject('i18n');
-import Message from '../Message.vue';
 
 const props = defineProps({
   selection: Object,


### PR DESCRIPTION
Prior to this fix, running `vue-tsc` results in a TS error: "src/components/Vuefinder/modals/ModalMove.vue:129:1 - error TS1473: An import declaration can only be used at the top level of a module."