### PR TITLE
Showing api errors without translation

### DIFF
--- a/src/components/modals/ModalArchive.vue
+++ b/src/components/modals/ModalArchive.vue
@@ -23,7 +23,7 @@
                  class="my-1 px-2 py-1 border rounded  dark:bg-gray-700/25 dark:focus:ring-gray-600 dark:focus:border-gray-600 dark:text-gray-100 w-full"
                  :placeholder="t('Archive name. (.zip file will be created)')" type="text">
 
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -77,7 +77,7 @@ const archive = () => {
         emitter.emit('vf-toast-push', {label: t('The file(s) archived.')});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalArchive.vue
+++ b/src/components/modals/ModalArchive.vue
@@ -77,7 +77,7 @@ const archive = () => {
         emitter.emit('vf-toast-push', {label: t('The file(s) archived.')});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalDelete.vue
+++ b/src/components/modals/ModalDelete.vue
@@ -20,7 +20,7 @@
               </svg>
             <span class="ml-1.5">{{ item.basename }}</span>
           </p>
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -75,7 +75,7 @@ const remove = () => {
         emitter.emit('vf-toast-push', {label: t('Files deleted.')});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalDelete.vue
+++ b/src/components/modals/ModalDelete.vue
@@ -75,7 +75,7 @@ const remove = () => {
         emitter.emit('vf-toast-push', {label: t('Files deleted.')});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalMove.vue
+++ b/src/components/modals/ModalMove.vue
@@ -82,7 +82,7 @@ const move = () => {
         emitter.emit('vf-toast-push', {label: t('Files moved.', props.selection.items.to.name)});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalMove.vue
+++ b/src/components/modals/ModalMove.vue
@@ -28,7 +28,7 @@
               </svg>
             <span class="ml-1.5 overflow-auto">{{ selection.items.to.path }}</span>
           </p>
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -82,7 +82,7 @@ const move = () => {
         emitter.emit('vf-toast-push', {label: t('Files moved.', props.selection.items.to.name)});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalNewFile.vue
+++ b/src/components/modals/ModalNewFile.vue
@@ -68,7 +68,7 @@ const createFile = () => {
         emitter.emit('vf-toast-push', {label: t('%s is created.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalNewFile.vue
+++ b/src/components/modals/ModalNewFile.vue
@@ -13,7 +13,7 @@
           <p class="text-sm text-gray-500">{{ t('Create a new file') }}</p>
           <input v-model="name" @keyup.enter="createFile"
                  class="px-2 py-1 border rounded dark:bg-gray-700/25 dark:focus:ring-gray-600 dark:focus:border-gray-600 dark:text-gray-100 w-full" :placeholder="t('File Name')" type="text">
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
 
         </div>
       </div>
@@ -68,7 +68,7 @@ const createFile = () => {
         emitter.emit('vf-toast-push', {label: t('%s is created.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalNewFolder.vue
+++ b/src/components/modals/ModalNewFolder.vue
@@ -13,7 +13,7 @@
           <p class="text-sm text-gray-500">{{ t('Create a new folder') }}</p>
           <input v-model="name" @keyup.enter="createFolder"
                  class="px-2 py-1 border rounded dark:bg-gray-700/25 dark:focus:ring-gray-600 dark:focus:border-gray-600 dark:text-gray-100 w-full" :placeholder="t('Folder Name')" type="text">
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -65,7 +65,7 @@ const createFolder = () => {
         emitter.emit('vf-toast-push', {label: t('%s is created.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalNewFolder.vue
+++ b/src/components/modals/ModalNewFolder.vue
@@ -65,7 +65,7 @@ const createFolder = () => {
         emitter.emit('vf-toast-push', {label: t('%s is created.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalRename.vue
+++ b/src/components/modals/ModalRename.vue
@@ -21,7 +21,7 @@
           </p>
           <input v-model="name" @keyup.enter="rename"
                  class="px-2 py-1 border rounded  dark:bg-gray-700/25 dark:focus:ring-gray-600 dark:focus:border-gray-600 dark:text-gray-100 w-full" placeholder="Name" type="text">
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -73,7 +73,7 @@ const rename = () => {
         emitter.emit('vf-toast-push', {label: t('%s is renamed.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message);
+        message.value = t(e.message) ? t(e.message) : e.message;
       }
     });
   }

--- a/src/components/modals/ModalRename.vue
+++ b/src/components/modals/ModalRename.vue
@@ -73,7 +73,7 @@ const rename = () => {
         emitter.emit('vf-toast-push', {label: t('%s is renamed.', name.value)});
       },
       onError: (e) => {
-        message.value = t(e.message) ? t(e.message) : e.message;
+        message.value = t(e.message);
       }
     });
   }

--- a/src/components/modals/ModalUnarchive.vue
+++ b/src/components/modals/ModalUnarchive.vue
@@ -72,7 +72,7 @@ const unarchive = () => {
       emitter.emit('vf-toast-push', {label: t('The file unarchived.')});
     },
     onError: (e) => {
-      message.value = t(e.message) ? t(e.message) : e.message;
+      message.value = t(e.message);
     }
   });
 };

--- a/src/components/modals/ModalUnarchive.vue
+++ b/src/components/modals/ModalUnarchive.vue
@@ -20,7 +20,7 @@
           </p>
           <p class="my-1 text-sm text-gray-500">{{ t('The archive will be unarchived at')}} ({{current.dirname}})</p>
 
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -72,7 +72,7 @@ const unarchive = () => {
       emitter.emit('vf-toast-push', {label: t('The file unarchived.')});
     },
     onError: (e) => {
-      message.value = t(e.message);
+      message.value = t(e.message) ? t(e.message) : e.message;
     }
   });
 };

--- a/src/components/modals/ModalUpload.vue
+++ b/src/components/modals/ModalUpload.vue
@@ -20,7 +20,7 @@
               <button ref="pickFiles"  type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
                 {{ t('Select Files') }}</button>
           </div>
-          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+          <message v-if="message && message.length" @hidden="message=''" error>{{ message }}</message>
         </div>
       </div>
     </div>
@@ -125,7 +125,7 @@ onMounted(() => {
         } else if (err.code == plupload.FILE_SIZE_ERROR) {
           message.value = t('The selected file exceeds the maximum file size. You cannot upload files greater than %s', [maxFileSize]);
         } else {
-          message.value = t(err.message);
+          message.value = t(err.message) ? t(err.message) : err.message;
         }
       }
     }


### PR DESCRIPTION
If an error response is received from the API, it can either contain a translation key OR a message shown to the end user as-is.

Just one example could be during "rename" if there is a conflict, and the backend can enlighten the user about this even if no translation key is present. If new translation keys are added, they will have precedence over the API response message according to the implementation of this commit.