### PR TITLE
Support transform request properly on upload

### DIFF
--- a/src/components/VueFinder.vue
+++ b/src/components/VueFinder.vue
@@ -93,7 +93,7 @@ const props = defineProps({
         multiple: false,
         click: (items) => {
           // items is an array of selected items
-          //
+          // 
         },
         ...rawProps,
       }

--- a/src/components/modals/ModalUpload.vue
+++ b/src/components/modals/ModalUpload.vue
@@ -333,11 +333,8 @@ onMounted(async () => {
     }
   });
 
-  const reqParams = buildReqParams()
   uppy.use(XHR, {
-    method: reqParams.method,
-    endpoint: reqParams.url + '?' + new URLSearchParams(reqParams.params),
-    headers: reqParams.headers,
+    endpoint: 'WILL_BE_REPLACED_BEFORE_UPLOAD',
     limit: 5,
     timeout: 0,
     getResponseError(responseText, _response) {
@@ -362,6 +359,10 @@ onMounted(async () => {
   uppy.on('upload', () => {
     const reqParams = buildReqParams();
     uppy.setMeta({ ...reqParams.body });
+    const xhrPlugin = uppy.getPlugin('XHRUpload');
+    xhrPlugin.opts.method = reqParams.method;
+    xhrPlugin.opts.endpoint = reqParams.url + '?' + new URLSearchParams(reqParams.params);
+    xhrPlugin.opts.headers = reqParams.headers;
     uploading.value = true;
     queue.value.forEach(file => {
       if (file.status === QUEUE_ENTRY_STATUS.DONE) {


### PR DESCRIPTION
I just realize we can set request body by call `uppy.setMeta()`, so I grab the request body come out from `requester.transformRequestParams()` and stick it in, now is properly transformed before upload.

~But unfortunately I don't think we can transform request method or query params, that just doesn't seems possible (or may be too expensive?). If I try set method or endpoint in XHR plugin config, nothing will happen after called `uppy.upload()` instead of actually starting sending files to the server. I haven't try swap XHR plugin before upload, that's kinda dumb tho.~

Nvm I literally found my way to do that part. Fixing right now.