### PR TITLE
fix multi file download problem

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -89,7 +89,6 @@ const menuItems = {
     link: computed(() => app.requester.getDownloadUrl(app.data.adapter, selectedItems.value[0])),
     title: () =>  t('Download'),
     action: () => {
-      console.log(1);
       const url = app.requester.getDownloadUrl(app.data.adapter, selectedItems.value[0]);
       app.emitter.emit('vf-download', url);
     },

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -2,16 +2,8 @@
   <ul class="z-30 absolute text-xs bg-neutral-50 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border border-neutral-300 dark:border-gray-600 shadow rounded select-none" ref="contextmenu" v-if="context.active" :style="context.positions">
     <li class="px-2 py-1.5 cursor-pointer hover:bg-neutral-200 dark:hover:bg-gray-700"
         v-for="(item) in filteredItems" :key="item.title" @click="run(item)">
-      <template v-if="item.link">
-        <a target="_blank" :href="item.link" :download="item.link">
-          <span class="px-1"></span>
-          <span>{{ item.title() }}</span>
-        </a>
-      </template>
-      <template v-else>
         <span class="px-1"></span>
         <span>{{ item.title() }}</span>
-      </template>
     </li>
   </ul>
 </template>
@@ -97,6 +89,7 @@ const menuItems = {
     link: computed(() => app.requester.getDownloadUrl(app.data.adapter, selectedItems.value[0])),
     title: () =>  t('Download'),
     action: () => {
+      console.log(1);
       const url = app.requester.getDownloadUrl(app.data.adapter, selectedItems.value[0]);
       app.emitter.emit('vf-download', url);
     },


### PR DESCRIPTION
To fix #47 ‘s download problem
I also met this problem when I was downloading some file using this package. 
I found the problem is that both using `A TAG` to download file and a emitter function callback which is named `vf-download`,  when click the `A TAG` clickable range,it will call two function both. When just click the  the li padding  range, it is right.I delete the function using `A TAG` to download file in template .