### PR TITLE
Open root path of adapter in TreeView

### DIFF
--- a/src/assets/css/components/_tree_view.scss
+++ b/src/assets/css/components/_tree_view.scss
@@ -141,7 +141,7 @@
 }
 
 .vuefinder__treestorageitem__loader {
-  @apply pointer-events-none pr-1;
+  @apply px-1;
 }
 
 .vuefinder__treestorageitem__subfolder {

--- a/src/components/TreeStorageItem.vue
+++ b/src/components/TreeStorageItem.vue
@@ -1,6 +1,6 @@
 <template>
-  <div
-    @click="showSubFolders = !showSubFolders"
+  <div 
+    @click="selectOrToggle(storage)"
     class="vuefinder__treestorageitem__header"
   >
     <div
@@ -16,7 +16,7 @@
       <div>{{ storage }}</div>
     </div>
 
-    <div class="vuefinder__treestorageitem__loader">
+    <div class="vuefinder__treestorageitem__loader" @click.stop="showSubFolders = !showSubFolders">
       <FolderLoaderIndicator :adapter="storage" :path="storage + '://'" v-model="showSubFolders" />
     </div>
   </div>
@@ -31,6 +31,7 @@ import FolderLoaderIndicator from "./FolderLoaderIndicator.vue";
 import TreeSubfolderList from "./TreeSubfolderList.vue";
 
 const app = inject('ServiceContainer');
+const {setStore} = app.storage;
 const showSubFolders = ref(false);
 const props = defineProps({
   storage: {
@@ -38,4 +39,21 @@ const props = defineProps({
     required: true,
   },
 });
+
+/**
+ * If the storage is active the visibilty of the subfolders gets toggled, otherwise the storage will become active 
+ * @param storage {string}
+ */
+function selectOrToggle(storage) {
+  if (storage === app.fs.adapter) {
+    // toggle list of subfolders
+    showSubFolders.value = !showSubFolders.value
+  } else {
+    // select storage
+    app.emitter.emit('vf-search-exit');
+    app.emitter.emit('vf-fetch', {params:{q: 'index', adapter: storage}});
+    setStore('adapter', storage);
+  }
+}
+
 </script>


### PR DESCRIPTION
Hi,

This PR makes it possible to open the root path of an adapter through the TreeView.

New behaviour when you click on the adapter name:
- Adapter is not selected: open root path
- Adapter is already selected: toggle visibility of subfolders

Result:

https://github.com/user-attachments/assets/e1ea6216-6ff9-414a-bc4e-987876795c6e


