### PR TITLE
Add linear loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,20 @@ To customize or update the styles, simply find the appropriate BEM class in the 
 
 ### Props
 
-| Prop          |     Value     | Default  | Description                                                |
-|---------------|:-------------:|----------|:-----------------------------------------------------------|
-| id            |    string     | _null_   | required                                                   |
-| request       | string/object | _object_ | required - backend url or request object, see above        |
-| locale        |    string     | en       | optional - default language code                           |
-| theme         |    string     | system   | optional - default theme, options: "system","light","dark" |
-| max-file-size |    string     | 10mb     | optional - client side max file upload                     |
-| max-height    |    string     | 600px    | optional - max height of the component                     |
-| features      |     array     | _null_   | optional - array of the enabled features                   |
-| path          |    string     | _null_   | optional - initial directory, example: 'media://public'    |
-| persist       |    boolean    | false    | optional - keep current directory on page refresh          |
-| full-screen   |    boolean    | false    | optional - start in full screen mode                       |
-| select-button |    object     | _object_ | optional - adds select button in status bar, see example   |
+| Prop              |     Value     | Default    | Description                                                 |
+|-------------------|:-------------:|------------|:------------------------------------------------------------|
+| id                |    string     | _null_     | required                                                    |
+| request           | string/object | _object_   | required - backend url or request object, see above         |
+| locale            |    string     | en         | optional - default language code                            |
+| theme             |    string     | system     | optional - default theme, options: "system","light","dark"  |
+| max-file-size     |    string     | 10mb       | optional - client side max file upload                      |
+| max-height        |    string     | 600px      | optional - max height of the component                      |
+| features          |     array     | _null_     | optional - array of the enabled features                    |
+| path              |    string     | _null_     | optional - initial directory, example: 'media://public'     |
+| persist           |    boolean    | false      | optional - keep current directory on page refresh           |
+| full-screen       |    boolean    | false      | optional - start in full screen mode                        |
+| select-button     |    object     | _object_   | optional - adds select button in status bar, see example    |
+| loading-indicator |    string     | circular   | optional - style of loading indicator: "circular", "linear" |
 
 
 ### Events

--- a/src/ServiceContainer.js
+++ b/src/ServiceContainer.js
@@ -87,6 +87,8 @@ export default (props, options) => {
         persist: persist,
         // show thumbnails
         showThumbnails: storage.getStore('show-thumbnails', props.showThumbnails),
+        // type of progress indicator
+        loadingIndicator: props.loadingIndicator,
 
         // file system
         fs: useData(adapter, path),

--- a/src/assets/css/components/_linear_loader.scss
+++ b/src/assets/css/components/_linear_loader.scss
@@ -1,0 +1,26 @@
+.dark .vuefinder__linear-loader {
+  --vuefinder__linear-loader-primary: theme(colors.slate.300);
+  --vuefinder__linear-loader-bg: theme(colors.slate.700);
+}
+
+// CREDIT: https://css-loaders.com/progress/
+.vuefinder__linear-loader {
+  --vuefinder__linear-loader-primary: theme(colors.sky.600);
+  --vuefinder__linear-loader-bg: theme(colors.sky.300);
+
+  position: absolute;
+  top: 0;
+  left: 0; 
+  right: 0;
+
+  height: 4px;
+  --vuefinder__linear-loader-gradient: no-repeat linear-gradient(var(--vuefinder__linear-loader-primary) 0 0);
+  background: var(--vuefinder__linear-loader-gradient),var(--vuefinder__linear-loader-gradient),var(--vuefinder__linear-loader-bg);
+  background-size: 60% 100%;
+  animation: vuefinder__linear-loader_keyframes 3s infinite;
+}
+@keyframes vuefinder__linear-loader_keyframes {
+  0%   {background-position:-150% 0,-150% 0}
+  66%  {background-position: 250% 0,-150% 0}
+  100% {background-position: 250% 0, 250% 0}
+}

--- a/src/assets/css/style.scss
+++ b/src/assets/css/style.scss
@@ -55,6 +55,7 @@
     @import "components/_folder_loader_indicator.scss";
     @import "components/_item.scss";
     @import "components/_item_icon.scss";
+    @import "components/_linear_loader.scss";
     @import "components/_message.scss";
     @import "components/_statusbar.scss";
     @import "components/_tree_view.scss";

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -61,7 +61,7 @@
         </div>
       </div>
 
-      <LoadingSVG v-if="app.fs.loading"/>
+      <LoadingSVG v-if="app.loadingIndicator === 'circular' && app.fs.loading"/>
     </div>
     <div v-show="app.fs.searchMode" class="vuefinder__breadcrumb__search-mode">
       <div>

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -28,6 +28,8 @@
          @contextmenu.self.prevent="app.emitter.emit('vf-contextmenu-show',{event: $event, items: ds.getSelected()})"
     >
 
+      <div class="vuefinder__linear-loader absolute" v-if="app.loadingIndicator === 'linear' && app.fs.loading"></div>
+
       <!-- Search View -->
       <Item v-if="searchQuery.length" v-for="(item, index) in getItems()"
             :item="item" :index="index" :dragImage="dragImage" class="vf-item vf-item-list">

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -70,7 +70,7 @@
         {{ t('Search results for') }}
         <span class="dark:bg-gray-700 bg-gray-200 text-xs px-2 py-1 rounded">{{ searchQuery }}</span>
       </div>
-      <LoadingSVG v-if="app.fs.loading" />
+      <LoadingSVG v-if="app.loadingIndicator === 'circular' && app.fs.loading" />
     </div>
 
     <div class="vuefinder__toolbar__controls">

--- a/src/components/VueFinder.vue
+++ b/src/components/VueFinder.vue
@@ -112,6 +112,10 @@ const props = defineProps({
       }
     },
   },
+  loadingIndicator: {
+    type: String,
+    default: 'circular'
+  }
 });
 
 // the object is passed to all components as props


### PR DESCRIPTION
I have added a linear progress indicator, because I wanted a more prominent indicator

New prop:
```typescript
loadingIndicator: {
  // possible values: 'circular' or 'linear'
  type: String,
  default: 'circular'
}
```

Example:
```vue
<vue-finder
  id='my_vuefinder2'
  :request="request"
  :max-file-size="maxFileSize"
  :features="features"
  loadingIndicator="linear"
  @select="handleSelect"
/>
```

Result:

https://github.com/user-attachments/assets/6691cf40-7c58-4036-b1dc-417b761e77d6


