### PR TITLE
Add modal to download an archive

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -23,6 +23,7 @@ import {FEATURES} from "../features.js";
 import ModalNewFolder from "./modals/ModalNewFolder.vue";
 import ModalPreview from "./modals/ModalPreview.vue";
 import ModalArchive from "./modals/ModalArchive.vue";
+import ModalDownloadArchive from "./modals/ModalDownloadArchive.vue";
 import ModalUnarchive from "./modals/ModalUnarchive.vue";
 import ModalRename from "./modals/ModalRename.vue";
 import ModalDelete from "./modals/ModalDelete.vue";
@@ -127,6 +128,11 @@ const menuItems = {
     action: () => {
     },
   },
+  download_archive: {
+    key: FEATURES.DOWNLOAD_ARCHIVE,
+    title: () => t('Download archive'),
+    action: () => app.modal.open(ModalDownloadArchive, {items: selectedItems}),
+  },
   archive: {
     key: FEATURES.ARCHIVE,
     title: () => t('Archive'),
@@ -174,6 +180,7 @@ app.emitter.on('vf-contextmenu-show', ({event, items, target = null}) => {
   } else if (items.length > 1 && items.some(el => el.path === target.path)) {
     context.items.push(menuItems.refresh);
     context.items.push(menuItems.archive);
+    context.items.push(menuItems.download_archive);
     context.items.push(menuItems.delete);
     app.emitter.emit('vf-context-selected', items);
     // console.log(items.length + ' selected (more than 1 item.)');
@@ -195,6 +202,7 @@ app.emitter.on('vf-contextmenu-show', ({event, items, target = null}) => {
       context.items.push(menuItems.unarchive);
     } else {
       context.items.push(menuItems.archive);
+      context.items.push(menuItems.download_archive);
     }
     context.items.push(menuItems.delete);
     app.emitter.emit('vf-context-selected', [target]);

--- a/src/components/modals/ModalDownloadArchive.vue
+++ b/src/components/modals/ModalDownloadArchive.vue
@@ -1,0 +1,66 @@
+<template>
+  <ModalLayout>
+    <div>
+      <ModalHeader :icon="ArchiveSVG" :title="t('Download archive')"></ModalHeader>
+      <div class="vuefinder__archive-modal__content">
+        <div class="vuefinder__archive-modal__form">
+          <div class="vuefinder__archive-modal__files vf-scrollbar">
+            <p v-for="item in items" class="vuefinder__archive-modal__file">
+              <svg v-if="item.type === 'dir'" class="vuefinder__archive-modal__icon vuefinder__archive-modal__icon--dir" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <svg v-else class="vuefinder__archive-modal__icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+              </svg>
+              <span class="vuefinder__archive-modal__file-name">{{ item.basename }}</span>
+            </p>
+          </div>
+          <input v-model="name" @keyup.enter="archive"
+                 class="vuefinder__archive-modal__input"
+                 :placeholder="t('Archive name. (.zip file will be created)')" type="text">
+          <message v-if="message.length" @hidden="message=''" error>{{ message }}</message>
+        </div>
+      </div>
+    </div>
+
+    <template v-slot:buttons>
+      <a
+        target="_blank"
+        class="vf-btn vf-btn-primary"
+        :download="getDownloadUrl(app.modal.data.adapter, app.modal.data.item)"
+        :href="getDownloadUrl(app.modal.data.adapter, app.modal.data.item)">{{ t('Download') }}</a>
+      <button type="button" @click="app.modal.close()" class="vf-btn vf-btn-secondary">{{ t('Cancel') }}</button>
+    </template>
+  </ModalLayout>
+</template>
+
+<script setup>
+import ModalLayout from './ModalLayout.vue';
+import {inject, ref} from 'vue';
+import Message from '../Message.vue';
+const app = inject('ServiceContainer');
+const {t} = app.i18n;
+import ArchiveSVG from "../icons/archive.svg";
+import ModalHeader from "./ModalHeader.vue";
+
+const name = ref('');
+const message = ref('');
+
+const items = ref(app.modal.data.items);
+
+const getDownloadUrl = () => {
+  const transform = app.requester.transformRequestParams({
+    url: '',
+    method: 'get',
+    params: { 
+      q: 'download_archive', 
+      adapter: app.fs.adapter,
+      path: app.fs.data.dirname, 
+      name: name.value, 
+      paths: JSON.stringify(items.value.map(({path}) => path)) 
+    }
+  });
+  return transform.url + '?' + new URLSearchParams(transform.params).toString()
+}
+
+</script>

--- a/src/features.js
+++ b/src/features.js
@@ -11,6 +11,7 @@ export const FEATURES = {
     DELETE: 'delete',
     FULL_SCREEN: 'fullscreen',
     DOWNLOAD: 'download',
+    DOWNLOAD_ARCHIVE: 'download_archive',
     LANGUAGE: 'language',
 }
 


### PR DESCRIPTION
I have added a new endpoint to the Python backend to [download an archive](https://github.com/abichinger/vuefinder-wsgi/blob/692cbf9321222fbda9048ef5000c61f08d8f1ff4/vuefinder/__init__.py#L289)

This PR adds a modal to call the new endpoint.
The context menu has a new entry called "Download archive".

![2024-09-18_14-11](https://github.com/user-attachments/assets/a8a924bd-ed15-4fc1-ae01-998ed9f85cb9)
