### PR TITLE
Make context menu customizable

### DIFF
--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="wrapper">
-    <div style="font-weight: bold;padding: 10px">Inline select button example</div>
+    
+    <label for="example">
+      Example
+    </label>
+    <div>
+      <select id="example" v-model="example">
+        <option v-for="(name, key) in examples" :value="key">{{ name }}</option>
+      </select>
+    </div>
+
+    <div style="font-weight: bold;padding: 10px">{{ examples[example] }}</div>
     <vue-finder
+      v-if="example === 'default'"
       id='my_vuefinder'
       :request="request"
       :max-file-size="maxFileSize"
@@ -9,27 +20,37 @@
       :select-button="handleSelectButton"
     />
 
-    <br>
-    <br>
-    <div style="font-weight: bold;padding: 10px">External select example</div>
+    <div v-if="example === 'externalSelect'">
+      <vue-finder
+        id='my_vuefinder2'
+        :request="request"
+        :max-file-size="maxFileSize"
+        :features="features"
+        loadingIndicator="linear"
+        @select="handleSelect"
+      />
+
+      <button class="btn" @click="handleButton" :disabled="!selectedFiles.length">Show Selected  ({{ selectedFiles.length ?? 0 }} selected)</button>
+
+      <div v-show="selectedFiles.length">
+        <h3>Selected Files ({{ selectedFiles.length }} selected)</h3>
+        <ul>
+          <li v-for="file in selectedFiles" :key="file.path">
+            {{ file.path }}
+          </li>
+        </ul>
+      </div>
+    </div>
+
     <vue-finder
-      id='my_vuefinder2'
+      v-if="example === 'contextmenu'"
+      id='my_vuefinder3'
       :request="request"
       :max-file-size="maxFileSize"
       :features="features"
-      @select="handleSelect"
+      :select-button="handleSelectButton"
+      :context-menu-items="customContextMenuItems"
     />
-
-    <button class="btn" @click="handleButton" :disabled="!selectedFiles.length">Show Selected  ({{ selectedFiles.length ?? 0 }} selected)</button>
-
-    <div v-show="selectedFiles.length">
-      <h3>Selected Files ({{ selectedFiles.length }} selected)</h3>
-      <ul>
-        <li v-for="file in selectedFiles" :key="file.path">
-          {{ file.path }}
-        </li>
-      </ul>
-    </div>
 
   </div>
 </template>
@@ -37,6 +58,14 @@
 <script setup>
 import { ref } from 'vue';
 import { FEATURES, FEATURE_ALL_NAMES } from '../src/features.js';
+import { contextMenuItems, SimpleContextMenuItem } from '../src/index.js';
+
+const example = ref('default')
+const examples = {
+  default: "Inline select button example",
+  externalSelect: "External select example",
+  contextmenu: "Custom context menu example",
+}
 
 /** @type {import('../src/utils/ajax.js').RequestConfig} */
 
@@ -99,6 +128,17 @@ const handleSelectButton = {
     console.log(items, event);
   }
 }
+
+const customContextMenuItems = [
+  ...contextMenuItems,
+  new SimpleContextMenuItem(() => 'Log Info', (app, selectedItems) => {
+    const info = selectedItems.value.map((i) => `Name: ${i.basename}, Type: ${i.type}, Path: ${i.path}`)
+    console.log(selectedItems.value.length + " item(s) selected:\n", info.join('\n'))
+    console.log(selectedItems.value)
+  }, undefined, {
+    target: undefined
+  })
+]
 
 </script>
 

--- a/src/ServiceContainer.js
+++ b/src/ServiceContainer.js
@@ -91,6 +91,8 @@ export default (props, options) => {
         showThumbnails: storage.getStore('show-thumbnails', props.showThumbnails),
         // type of progress indicator
         loadingIndicator: props.loadingIndicator,
+        // possible items of the context menu
+        contextMenuItems: props.contextMenuItems,
 
         // file system
         fs: useData(adapter, path),

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,16 +1,16 @@
 <template>
   <ul ref="contextmenu" v-show="context.active" :style="context.positions"
       class="vuefinder__context-menu">
-    <li class="vuefinder__context-menu__item" v-for="(item) in filteredItems" :key="item.title">
+    <li class="vuefinder__context-menu__item" v-for="(item) in context.items" :key="item.title">
       <template v-if="item.link">
-        <a class="vuefinder__context-menu__link" target="_blank" :href="item.link" :download="item.link"
+        <a class="vuefinder__context-menu__link" target="_blank" :href="link(item)" :download="link(item)"
            @click="app.emitter.emit('vf-contextmenu-hide')">
-          <span>{{ item.title() }}</span>
+          <span>{{ item.title(app.i18n) }}</span>
         </a>
       </template>
       <template v-else>
         <div class="vuefinder__context-menu__action" @click="run(item)">
-          <span>{{ item.title() }}</span>
+          <span>{{ item.title(app.i18n) }}</span>
         </div>
       </template>
     </li>
@@ -18,17 +18,9 @@
 </template>
 
 <script setup>
-import {computed, inject, nextTick, reactive, ref} from 'vue';
-import {FEATURES} from "../features.js";
-import ModalNewFolder from "./modals/ModalNewFolder.vue";
-import ModalPreview from "./modals/ModalPreview.vue";
-import ModalArchive from "./modals/ModalArchive.vue";
-import ModalUnarchive from "./modals/ModalUnarchive.vue";
-import ModalRename from "./modals/ModalRename.vue";
-import ModalDelete from "./modals/ModalDelete.vue";
+import { inject, nextTick, reactive, ref} from 'vue';
 
 const app = inject('ServiceContainer');
-const {t} = app.i18n
 
 const contextmenu = ref(null);
 const selectedItems = ref([]);
@@ -43,160 +35,48 @@ const context = reactive({
   }
 });
 
-const filteredItems = computed(() => {
-  return context.items.filter(item => item.key == null || app.features.includes(item.key))
-});
+
 
 app.emitter.on('vf-context-selected', (items) => {
   selectedItems.value = items;
 })
 
-const menuItems = {
-  newfolder: {
-    key: FEATURES.NEW_FOLDER,
-    title: () => t('New Folder'),
-    action: () => app.modal.open(ModalNewFolder),
-  },
-  selectAll: {
-    title: () => t('Select All'),
-    action: () => app.dragSelect.selectAll(),
-  },
-  pinFolder: {
-    title: () => t('Pin Folder'),
-    action: () => {
-        app.pinnedFolders = app.pinnedFolders.concat(selectedItems.value);
-        app.storage.setStore('pinned-folders', app.pinnedFolders);
-    },
-  },
-
-  unpinFolder: {
-    title: () => t('Unpin Folder'),
-    action: () => {
-        app.pinnedFolders = app.pinnedFolders.filter(fav => !selectedItems.value.find(item => item.path === fav.path));
-        app.storage.setStore('pinned-folders', app.pinnedFolders);
-    },
-  },
-  delete: {
-    key: FEATURES.DELETE,
-    title: () => t('Delete'),
-    action: () => {
-      app.modal.open(ModalDelete, {items: selectedItems});
-    },
-  },
-  refresh: {
-    title: () => t('Refresh'),
-    action: () => {
-      app.emitter.emit('vf-fetch', {params: {q: 'index', adapter: app.fs.adapter, path: app.fs.data.dirname}});
-    },
-  },
-  preview: {
-    key: FEATURES.PREVIEW,
-    title: () => t('Preview'),
-    action: () => app.modal.open(ModalPreview, {adapter: app.fs.adapter, item: selectedItems.value[0]}),
-  },
-  open: {
-    title: () => t('Open'),
-    action: () => {
-      app.emitter.emit('vf-search-exit');
-      app.emitter.emit('vf-fetch', {
-        params: {
-          q: 'index',
-          adapter: app.fs.adapter,
-          path: selectedItems.value[0].path
-        }
-      });
-    },
-  },
-  openDir: {
-    title: () => t('Open containing folder'),
-    action: () => {
-      app.emitter.emit('vf-search-exit');
-      app.emitter.emit('vf-fetch', {
-        params: {
-          q: 'index',
-          adapter: app.fs.adapter,
-          path: (selectedItems.value[0].dir)
-        }
-      });
-    },
-  },
-  download: {
-    key: FEATURES.DOWNLOAD,
-    link: computed(() => app.requester.getDownloadUrl(app.fs.adapter, selectedItems.value[0])),
-    title: () => t('Download'),
-    action: () => {
-    },
-  },
-  archive: {
-    key: FEATURES.ARCHIVE,
-    title: () => t('Archive'),
-    action: () => app.modal.open(ModalArchive, {items: selectedItems}),
-  },
-  unarchive: {
-    key: FEATURES.UNARCHIVE,
-    title: () => t('Unarchive'),
-    action: () => app.modal.open(ModalUnarchive, {items: selectedItems}),
-  },
-  rename: {
-    key: FEATURES.RENAME,
-    title: () => t('Rename'),
-    action: () => app.modal.open(ModalRename, {items: selectedItems}),
-  }
-};
+const link = (item) => {
+  return item.link(app, selectedItems)
+}
 
 const run = (item) => {
   app.emitter.emit('vf-contextmenu-hide');
-  item.action();
+  item.action(app, selectedItems);
 };
-
 
 app.emitter.on('vf-search-query', ({newQuery}) => {
   searchQuery.value = newQuery;
 });
 
 app.emitter.on('vf-contextmenu-show', ({event, items, target = null}) => {
-  context.items = [];
+  context.items = app.contextMenuItems.filter((item) => {
+    return item.show(app, {
+      searchQuery: searchQuery.value, 
+      items, 
+      target
+    })
+  });
 
   if (searchQuery.value) {
     if (target) {
-      context.items.push(menuItems.openDir);
       app.emitter.emit('vf-context-selected', [target]);
       // console.log('search item selected');
     } else {
       return;
     }
   } else if (!target && !searchQuery.value) {
-    context.items.push(menuItems.refresh);
-    context.items.push(menuItems.selectAll);
-    context.items.push(menuItems.newfolder);
     app.emitter.emit('vf-context-selected', []);
     // console.log('no files selected');
   } else if (items.length > 1 && items.some(el => el.path === target.path)) {
-    context.items.push(menuItems.refresh);
-    context.items.push(menuItems.archive);
-    context.items.push(menuItems.delete);
     app.emitter.emit('vf-context-selected', items);
     // console.log(items.length + ' selected (more than 1 item.)');
   } else {
-    if (target.type === 'dir') {
-      context.items.push(menuItems.open);
-      if (app.pinnedFolders.findIndex((item) => item.path === target.path) !== -1) {
-        context.items.push(menuItems.unpinFolder);
-      } else {
-        context.items.push(menuItems.pinFolder);
-      }
-    } else {
-      context.items.push(menuItems.preview);
-      context.items.push(menuItems.download);
-    }
-    context.items.push(menuItems.rename);
-
-    if (target.mime_type === 'application/zip') {
-      context.items.push(menuItems.unarchive);
-    } else {
-      context.items.push(menuItems.archive);
-    }
-    context.items.push(menuItems.delete);
     app.emitter.emit('vf-context-selected', [target]);
     // console.log(target.type + ' is selected');
   }

--- a/src/components/VueFinder.vue
+++ b/src/components/VueFinder.vue
@@ -37,6 +37,7 @@ import Explorer from '../components/Explorer.vue';
 import ContextMenu from '../components/ContextMenu.vue';
 import Statusbar from '../components/Statusbar.vue';
 import TreeView from '../components/TreeView.vue';
+import { menuItems as contextMenuItems } from '../utils/contextmenu.js';
 
 
 const emit = defineEmits(['select', 'update:path'])
@@ -119,8 +120,11 @@ const props = defineProps({
   loadingIndicator: {
     type: String,
     default: 'circular'
-
-  }
+  },
+  contextMenuItems: {
+    type: Array,
+    default: () => contextMenuItems
+  },
 });
 
 // the object is passed to all components as props

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import VueFinder from './components/VueFinder.vue';
 import './assets/css/style.scss';
+import { menuItems, SimpleItem } from './utils/contextmenu';
 
 export default {
     /**
@@ -20,4 +21,7 @@ export default {
     }
 };
 
-
+export {
+    menuItems as contextMenuItems,
+    SimpleItem as SimpleContextMenuItem,
+}

--- a/src/utils/contextmenu.js
+++ b/src/utils/contextmenu.js
@@ -1,0 +1,245 @@
+import {computed} from 'vue';
+import {FEATURES} from "../features.js";
+import ModalNewFolder from "../components/modals/ModalNewFolder.vue";
+import ModalPreview from "../components/modals/ModalPreview.vue";
+import ModalArchive from "../components/modals/ModalArchive.vue";
+import ModalUnarchive from "../components/modals/ModalUnarchive.vue";
+import ModalRename from "../components/modals/ModalRename.vue";
+import ModalDelete from "../components/modals/ModalDelete.vue";
+
+/**
+ * @typedef {typeof import('../ServiceContainer.js')['default']} ServiceContainer
+ * @typedef {ReturnType<ServiceContainer>} App
+ * 
+ * @typedef {any} DirEntry
+ * 
+ * @typedef MenuContext
+ * @prop {string} searchQuery
+ * @prop {DirEntry[]} items
+ * @prop {DirEntry | null} target
+ * 
+ * 
+ * @typedef Item
+ * @prop {(i18n: App['i18n']) => string} title
+ * @prop {(app: App, selectedItems: DirEntry[]) => void} action
+ * @prop {(app: App, selectedItems: DirEntry[]) => void} [link]
+ * @prop {(app: App, ctx: MenuContext) => boolean} show
+ * 
+ * @typedef ItemTemplate
+ * @prop {Item['title']} title
+ * @prop {Item['action']} action
+ * @prop {Item['link']} [link]
+ * @prop {string} [key]
+ * 
+ * @typedef SimpleItemOptions
+ * @prop {boolean} needsSearchQuery (default: `false`)
+ * @prop {null|'one'|'many'} target (default: `'one'`)
+ * @prop {string} targetType
+ * @prop {string} mimeType
+ * @prop {string} feature
+ * @prop {Item['show']} show
+ */
+
+/**
+ * @class
+ * @implements {Item}
+ */
+export class SimpleItem {
+
+  /**
+   * 
+   * @param {Item['title']} title 
+   * @param {Item['action']} action 
+   * @param {Item['link']} link
+   * @param {Partial<SimpleItemOptions>} options 
+   */
+  constructor(title, action, link, options) {
+    this.title = title
+    this.action = action
+    this.link = link
+    this.options = Object.assign(
+      {
+        needsSearchQuery: false, 
+        target: 'one',
+      }, 
+      options,
+    )
+  }
+
+  /**
+   * @type {Item['show']}
+   */
+  show(app, ctx) {
+    /** @type {(ctx: MenuContext) => SimpleItemOptions['target']} */
+    const actualTarget = (ctx) => {
+      if (ctx.items.length > 1 && ctx.items.some((item) => item.path === ctx.target?.path)) {
+        return 'many'
+      }
+      return ctx.target ? 'one' : null
+    }
+
+    if (this.options.needsSearchQuery !== !!ctx.searchQuery) {
+      return false
+    }
+    if (this.options.target !== undefined && this.options.target !== actualTarget(ctx)) {
+      return false
+    }
+    if (this.options.targetType !== undefined && this.options.targetType !== ctx.target?.type) {
+      return false
+    }
+    if (this.options.mimeType !== undefined && this.options.mimeType !== ctx.target?.mime_type) {
+      return false
+    }
+    if (this.options.feature !== undefined && !app.features.includes(this.options.feature)) {
+      return false
+    }
+    if (this.options.show !== undefined && !this.options.show(app, ctx)) {
+      return false
+    }
+
+    return true
+  }
+}
+
+/**
+ * 
+ * @param {ItemTemplate[]} templates 
+ * @param {SimpleItemOptions} options
+ * @returns {Item[]}
+ */
+function itemBundle(templates, options) {
+  return templates.map((template) => {
+    return new SimpleItem(template.title, template.action, template.link, {
+      ...options,
+      feature: template.key
+    })
+  })
+}
+
+/** @type {Record<string, ItemTemplate>} */
+const templateMap = {
+  newfolder: {
+    key: FEATURES.NEW_FOLDER,
+    title: ({t}) => t('New Folder'),
+    action: (app) => app.modal.open(ModalNewFolder),
+  },
+  selectAll: {
+    title: ({t}) => t('Select All'),
+    action: (app) => app.dragSelect.selectAll(),
+  },
+  pinFolder: {
+    title: ({t}) => t('Pin Folder'),
+    action: (app, selectedItems) => {
+        app.pinnedFolders = app.pinnedFolders.concat(selectedItems.value);
+        app.storage.setStore('pinned-folders', app.pinnedFolders);
+    },
+  },
+
+  unpinFolder: {
+    title: ({t}) => t('Unpin Folder'),
+    action: (app, selectedItems) => {
+        app.pinnedFolders = app.pinnedFolders.filter(fav => !selectedItems.value.find(item => item.path === fav.path));
+        app.storage.setStore('pinned-folders', app.pinnedFolders);
+    },
+  },
+  delete: {
+    key: FEATURES.DELETE,
+    title: ({t}) => t('Delete'),
+    action: (app, selectedItems) => {
+      app.modal.open(ModalDelete, {items: selectedItems});
+    },
+  },
+  refresh: {
+    title: ({t}) => t('Refresh'),
+    action: (app) => {
+      app.emitter.emit('vf-fetch', {params: {q: 'index', adapter: app.fs.adapter, path: app.fs.data.dirname}});
+    },
+  },
+  preview: {
+    key: FEATURES.PREVIEW,
+    title: ({t}) => t('Preview'),
+    action: (app, selectedItems) => app.modal.open(ModalPreview, {adapter: app.fs.adapter, item: selectedItems.value[0]}),
+  },
+  open: {
+    title: ({t}) => t('Open'),
+    action: (app, selectedItems) => {
+      app.emitter.emit('vf-search-exit');
+      app.emitter.emit('vf-fetch', {
+        params: {
+          q: 'index',
+          adapter: app.fs.adapter,
+          path: selectedItems.value[0].path
+        }
+      });
+    },
+  },
+  openDir: {
+    title: ({t}) => t('Open containing folder'),
+    action: (app, selectedItems) => {
+      app.emitter.emit('vf-search-exit');
+      app.emitter.emit('vf-fetch', {
+        params: {
+          q: 'index',
+          adapter: app.fs.adapter,
+          path: (selectedItems.value[0].dir)
+        }
+      });
+    },
+  },
+  download: {
+    key: FEATURES.DOWNLOAD,
+    link: (app, selectedItems) => app.requester.getDownloadUrl(app.fs.adapter, selectedItems.value[0]),
+    title: ({t}) => t('Download'),
+    action: () => {},
+  },
+  archive: {
+    key: FEATURES.ARCHIVE,
+    title: ({t}) => t('Archive'),
+    action: (app, selectedItems) => app.modal.open(ModalArchive, {items: selectedItems}),
+  },
+  unarchive: {
+    key: FEATURES.UNARCHIVE,
+    title: ({t}) => t('Unarchive'),
+    action: (app, selectedItems) => app.modal.open(ModalUnarchive, {items: selectedItems}),
+  },
+  rename: {
+    key: FEATURES.RENAME,
+    title: ({t}) => t('Rename'),
+    action: (app, selectedItems) => app.modal.open(ModalRename, {items: selectedItems}),
+  }
+};
+
+/** @type {Item[]} */
+export const menuItems = [
+  ...itemBundle([templateMap.openDir], {
+    needsSearchQuery: true,
+  }),
+  ...itemBundle([templateMap.refresh, templateMap.selectAll, templateMap.newfolder], {
+    target: null,
+  }),
+  ...itemBundle([templateMap.refresh, templateMap.archive, templateMap.delete], {
+    target: 'many'
+  }),
+  ...itemBundle([templateMap.open], {
+    targetType: 'dir',
+  }),
+  ...itemBundle([templateMap.unpinFolder], {
+    targetType: 'dir',
+    show: (app, ctx) => app.pinnedFolders.findIndex((item) => item.path === ctx.target?.path) !== -1
+  }),
+  ...itemBundle([templateMap.pinFolder], {
+    targetType: 'dir',
+    show: (app, ctx) => app.pinnedFolders.findIndex((item) => item.path === ctx.target?.path) === -1
+  }),
+  ...itemBundle([templateMap.preview, templateMap.download], {
+    show: (app, ctx) => ctx.target?.type !== 'dir'
+  }),
+  ...itemBundle([templateMap.rename], {numItems: 'one',}),
+  ...itemBundle([templateMap.unarchive], {
+    mimeType: 'application/zip',
+  }),
+  ...itemBundle([templateMap.archive], {
+    show: (app, ctx) => ctx.target?.mime_type !== 'application/zip'
+  }),
+  ...itemBundle([templateMap.delete], {}),
+]


### PR DESCRIPTION
This PR adds support for custom context menu items.

Overview of changes:

- Added prop called `contextMenuItems`
https://github.com/abichinger/vuefinder/blob/0dea1a006028c55a24286a2b9a1f9dae92cfbc49/src/components/VueFinder.vue#L124
- New library exports: `contextMenuItems` and `SimpleContextMenuItem`
https://github.com/abichinger/vuefinder/blob/0dea1a006028c55a24286a2b9a1f9dae92cfbc49/src/index.js#L24
- New example called: Custom context menu example
https://github.com/abichinger/vuefinder/blob/0dea1a006028c55a24286a2b9a1f9dae92cfbc49/examples/App.vue#L52
- This is the type of an item:
```typescript
type ContextMenuItem = {
    title: (i18n: App["i18n"]) => string;
    action: (app: App, selectedItems: DirEntry[]) => void;
    link?: (app: App, selectedItems: DirEntry[]) => void;
    show: (app: App, ctx: MenuContext) => boolean;
}
```