### PR TITLE
Add fetch interceptors and custom parameters

### DIFF
--- a/src/utils/ajax.js
+++ b/src/utils/ajax.js
@@ -8,6 +8,7 @@ export const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttrib
  * @property {Record<String,*>=} body Additional body key pairs
  * @property {RequestTransformer=} transformRequest Transform request callback
  * @property {String=} xsrfHeaderName The http header that carries the xsrf token value
+ * @property {Record<String,*>=} fetchParams Additional options for fetch request
  */
 /**
  * @typedef RequestTransformParams
@@ -33,6 +34,7 @@ export const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttrib
  * @property {Record<String, ?String>} params
  * @property {Record<String,?String>|FormData=} body
  */
+
 /**
  * @callback RequestTransformer
  * @param {RequestTransformParams} request
@@ -66,7 +68,7 @@ export class Requester {
      * @param {Record<String,?String>|FormData=} input.body
      * @return {RequestTransformResultInternal}
      */
-    transformRequestParams(input ) {
+    transformRequestParams(input) {
         const config = this.config;
         const ourHeaders = {};
         if (csrf != null && csrf !== '') {
@@ -83,7 +85,7 @@ export class Requester {
             /** @type {Record<String,*>|FormData} */
             if (!(body instanceof FormData)) {
                 // JSON
-                newBody = { ...body };
+                newBody = {...body};
                 if (config.body != null) {
                     Object.assign(newBody, this.config.body);
                 }
@@ -147,7 +149,7 @@ export class Requester {
         const transform = this.transformRequestParams({
             url: '',
             method: 'get',
-            params: { q: 'download', adapter, path: node.path }
+            params: {q: 'download', adapter, path: node.path}
         });
         return transform.url + '?' + new URLSearchParams(transform.params).toString()
     }
@@ -167,7 +169,7 @@ export class Requester {
         const transform = this.transformRequestParams({
             url: '',
             method: 'get',
-            params: { q: 'preview', adapter, path: node.path }
+            params: {q: 'preview', adapter, path: node.path}
         });
         return transform.url + '?' + new URLSearchParams(transform.params).toString()
     }
@@ -208,6 +210,11 @@ export class Requester {
             }
             init.body = newBody;
         }
+
+        if (this.config.fetchParams) {
+            Object.assign(init, this.config.fetchParams);
+        }
+
         const response = await fetch(url, init);
         if (response.ok) {
             return await response[responseType]();
@@ -229,12 +236,14 @@ export function buildRequester(userConfig) {
         params: {},
         body: {},
         xsrfHeaderName: 'X-CSRF-Token',
+        fetchParams: {}
     };
     if (typeof userConfig === 'string') {
-        Object.assign(config, { baseUrl: userConfig });
+        Object.assign(config, {baseUrl: userConfig});
     } else {
         Object.assign(config, userConfig);
     }
+
     return new Requester(config);
 }
 


### PR DESCRIPTION
This PR provides a set of custom attributes for fetch requests including request and response interceptors.

```vue
<script setup>
  const request = "http://vuefinder-php.test"
  
  // Or ...
  const request = {
    // ----- CHANGE ME! -----
    // [REQUIRED] Url for development server endpoint
    baseUrl: "http://vuefinder-php.test",
    // ----- CHANGE ME! -----

    // Additional headers & params & body
    headers: { "X-ADDITIONAL-HEADER": 'yes' },
    params: { additionalParam1: 'yes' },
    body: { additionalBody1: ['yes'] },

    // And/or transform request callback
    transformRequest: req => {
      if (req.method === 'get') {
        req.params.vf = "1"
      }
      return req;
    },

    // XSRF Token header name
    xsrfHeaderName: "X-CSRF-TOKEN",

    // Custom fetch parameters
    fetchParams: {
      'credentials': 'include',
      'mode': 'cors'
    },

    fetchRequestInterceptor: (req: any) => {
      console.log(req)
      return req;
    },

    fetchResponseInterceptor: async (response: any) => {
      console.log(response)
      return response;
    },
  }
</script>
```