### PR TITLE
Fix: openapi docs / path in upload request

### DIFF
--- a/docs/api-reference/openapi.md
+++ b/docs/api-reference/openapi.md
@@ -197,9 +197,10 @@ Note: Delete endpoint returns the updated file list (same format as list endpoin
 ### Upload Request
 
 ```
-POST {baseUrl}/upload?path=local://uploads
+POST {baseUrl}/upload
 Content-Type: multipart/form-data
 
+path: [destination folder path]
 file: [binary file data]
 ```
 

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -401,16 +401,8 @@ paths:
       tags:
         - Files
       summary: Upload files
-      description: Upload one or more files to the specified directory. Uses multipart/form-data encoding. The file field name should be 'file'. The target path should be provided as a query parameter.
+      description: Upload one or more files to the specified directory. Uses multipart/form-data encoding. The file field name should be 'file'. The target path should be in 'path' field.
       operationId: uploadFiles
-      parameters:
-        - name: path
-          in: query
-          required: true
-          description: Target directory path for upload (including storage prefix)
-          schema:
-            type: string
-          example: "local://uploads"
       requestBody:
         required: true
         content:


### PR DESCRIPTION
This fixes a mistake in OpenAPI documentation: currently `path` is defined in request body, not in query parameters