### PR TITLE
feat(upload): inline rename of files inside the upload dialog

### DIFF
--- a/src/assets/css/components/modals/_modal_upload.css
+++ b/src/assets/css/components/modals/_modal_upload.css
@@ -58,6 +58,42 @@
   @apply h-5 w-5;
 }
 
+.vuefinder__themer .vuefinder__upload-modal__file-rename-action {
+  @apply mr-1 ml-auto flex h-5 w-5 items-center justify-center rounded border border-(--vf-border-primary) bg-(--vf-bg-tertiary) text-(--vf-text-secondary) focus:outline-none;
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-action:hover {
+  @apply text-(--vf-accent-primary);
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-action.disabled {
+  @apply bg-(--vf-bg-disabled) opacity-50;
+}
+
+.vuefinder__upload-modal__file-rename {
+  @apply flex items-center gap-1;
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-input {
+  @apply h-6 flex-1 rounded border border-(--vf-border-primary) bg-(--vf-bg-primary) px-1 text-sm text-(--vf-text-primary) focus:outline-none;
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-btn {
+  @apply flex h-5 w-5 shrink-0 items-center justify-center rounded border border-(--vf-border-primary) bg-(--vf-bg-tertiary) text-(--vf-text-secondary) focus:outline-none;
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-btn--save {
+  @apply text-(--vf-accent-success);
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-btn:hover {
+  @apply text-(--vf-text-primary);
+}
+
+.vuefinder__themer .vuefinder__upload-modal__file-rename-icon {
+  @apply h-4 w-4;
+}
+
 /* Upload actions (Select Files + caret) */
 .vuefinder__upload-actions {
   @apply inline-flex items-stretch;

--- a/src/components/modals/ModalUpload.vue
+++ b/src/components/modals/ModalUpload.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, onUnmounted, nextTick, ref } from 'vue';
+import type { QueueEntry } from '../../composables/useUpload';
 import { useStore } from '@nanostores/vue';
 import Message from '../../components/Message.vue';
 import ModalHeader from '../../components/modals/ModalHeader.vue';
@@ -72,7 +73,50 @@ const {
   getClassNameForEntry,
   getIconForEntry,
   addExternalFiles,
+  renameEntry,
 } = useUpload(app.customUploader);
+
+// Inline rename state
+const editingId = ref<string | null>(null);
+const editingName = ref('');
+const renameInputRef = ref<HTMLInputElement | null>(null);
+
+// Extract just the basename portion (drops any subfolder prefix from folder uploads).
+const entryBasename = (name: string): string => {
+  const i = name.lastIndexOf('/');
+  return i === -1 ? name : name.slice(i + 1);
+};
+
+const startEdit = (entry: QueueEntry) => {
+  if (uploading.value) return;
+  if (entry.status === definitions.value.QUEUE_ENTRY_STATUS.UPLOADING) return;
+  editingId.value = entry.id;
+  editingName.value = entryBasename(entry.name);
+  nextTick(() => {
+    const input = renameInputRef.value;
+    if (input) {
+      input.focus();
+      const dotIndex = editingName.value.lastIndexOf('.');
+      if (dotIndex > 0) input.setSelectionRange(0, dotIndex);
+      else input.select();
+    }
+  });
+};
+
+const cancelEdit = () => {
+  editingId.value = null;
+  editingName.value = '';
+};
+
+const submitEdit = async (entry: QueueEntry) => {
+  const newName = editingName.value.trim();
+  if (!newName || newName === entryBasename(entry.name)) {
+    cancelEdit();
+    return;
+  }
+  await renameEntry(entry, newName);
+  cancelEdit();
+};
 
 // Override upload function to use target folder
 const upload = () => {
@@ -170,25 +214,111 @@ onUnmounted(() => document.removeEventListener('click', onClickOutside));
               ></span>
             </span>
             <div class="vuefinder__upload-modal__file-info">
-              <div class="vuefinder__upload-modal__file-name hidden md:block">
-                {{ titleShorten(entry.name, 40) }} ({{ entry.size }})
-              </div>
-              <div class="vuefinder__upload-modal__file-name md:hidden">
-                {{ titleShorten(entry.name, 16) }} ({{ entry.size }})
-              </div>
-              <div
-                class="vuefinder__upload-modal__file-status"
-                :class="getClassNameForEntry(entry)"
-              >
-                {{ entry.statusName }}
-                <b
-                  v-if="entry.status === definitions.QUEUE_ENTRY_STATUS.UPLOADING"
-                  class="ml-auto"
-                  >{{ entry.percent }}</b
+              <template v-if="editingId === entry.id">
+                <div class="vuefinder__upload-modal__file-rename">
+                  <input
+                    ref="renameInputRef"
+                    v-model="editingName"
+                    type="text"
+                    class="vuefinder__upload-modal__file-rename-input"
+                    :placeholder="t('Rename')"
+                    @keyup.enter="submitEdit(entry)"
+                    @keyup.esc="cancelEdit"
+                  />
+                  <button
+                    type="button"
+                    class="vuefinder__upload-modal__file-rename-btn vuefinder__upload-modal__file-rename-btn--save"
+                    :title="t('Save')"
+                    @click="submitEdit(entry)"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="2"
+                      stroke="currentColor"
+                      class="vuefinder__upload-modal__file-rename-icon"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M4.5 12.75l6 6 9-13.5"
+                      ></path>
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    class="vuefinder__upload-modal__file-rename-btn"
+                    :title="t('Cancel')"
+                    @click="cancelEdit"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="2"
+                      stroke="currentColor"
+                      class="vuefinder__upload-modal__file-rename-icon"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M6 18L18 6M6 6l12 12"
+                      ></path>
+                    </svg>
+                  </button>
+                </div>
+              </template>
+              <template v-else>
+                <div class="vuefinder__upload-modal__file-name hidden md:block">
+                  {{ titleShorten(entry.name, 40) }} ({{ entry.size }})
+                </div>
+                <div class="vuefinder__upload-modal__file-name md:hidden">
+                  {{ titleShorten(entry.name, 16) }} ({{ entry.size }})
+                </div>
+                <div
+                  class="vuefinder__upload-modal__file-status"
+                  :class="getClassNameForEntry(entry)"
                 >
-              </div>
+                  {{ entry.statusName }}
+                  <b
+                    v-if="entry.status === definitions.QUEUE_ENTRY_STATUS.UPLOADING"
+                    class="ml-auto"
+                    >{{ entry.percent }}</b
+                  >
+                </div>
+              </template>
             </div>
             <button
+              v-if="editingId !== entry.id"
+              type="button"
+              class="vuefinder__upload-modal__file-rename-action"
+              :class="
+                uploading || entry.status === definitions.QUEUE_ENTRY_STATUS.UPLOADING
+                  ? 'disabled'
+                  : ''
+              "
+              :title="t('Rename')"
+              :disabled="uploading || entry.status === definitions.QUEUE_ENTRY_STATUS.UPLOADING"
+              @click="startEdit(entry)"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="vuefinder__upload-modal__file-rename-icon"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                ></path>
+              </svg>
+            </button>
+            <button
+              v-if="editingId !== entry.id"
               type="button"
               class="vuefinder__upload-modal__file-remove"
               :class="uploading ? 'disabled' : ''"

--- a/src/composables/useUpload.ts
+++ b/src/composables/useUpload.ts
@@ -46,6 +46,7 @@ export interface UseUploadReturn {
   getClassNameForEntry: (entry: QueueEntry) => string;
   getIconForEntry: (entry: QueueEntry) => string;
   addExternalFiles: (files: File[]) => void;
+  renameEntry: (entry: QueueEntry, newName: string) => Promise<void>;
 }
 
 export default function useUpload(customUploader?: any): UseUploadReturn {
@@ -190,6 +191,61 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
     files.forEach((file) => {
       addFile(file);
     });
+  };
+
+  const joinFolderAndName = (folder: string, name: string): string => {
+    if (folder.endsWith('://') || folder.endsWith('/')) return folder + name;
+    return folder + '/' + name;
+  };
+
+  const renameEntry = async (entry: QueueEntry, newName: string): Promise<void> => {
+    const trimmed = newName.trim();
+    if (uploading.value) return;
+    if (!trimmed || trimmed === entry.name) return;
+    if (trimmed.includes('/') || trimmed.includes('\\')) {
+      message.value = t('Name cannot contain slashes.');
+      return;
+    }
+
+    if (entry.status === QUEUE_ENTRY_STATUS.DONE) {
+      const targetFolderPath = uploadTargetFolder.value?.path || currentPath.value.path;
+      // Preserve any subfolder prefix from folder uploads (e.g. "sub/file.txt").
+      const segments = entry.name.split('/');
+      segments[segments.length - 1] = trimmed;
+      const newEntryName = segments.join('/');
+      const itemPath = joinFolderAndName(targetFolderPath, entry.name);
+      const parentSegments = entry.name.split('/');
+      parentSegments.pop();
+      const parentPath = parentSegments.length
+        ? joinFolderAndName(targetFolderPath, parentSegments.join('/'))
+        : targetFolderPath;
+
+      try {
+        await app.adapter.rename({ path: parentPath, item: itemPath, name: trimmed });
+        entry.name = newEntryName;
+        app.adapter.invalidateListQuery(targetFolderPath);
+        if (targetFolderPath === currentPath.value.path) {
+          app.adapter.open(targetFolderPath);
+        }
+      } catch (e: any) {
+        message.value = e?.message || t('Failed to rename');
+      }
+      return;
+    }
+
+    // Pending / error / canceled — rename locally by re-adding to uppy with the new name.
+    const idx = findQueueEntryIndexById(entry.id);
+    if (idx === -1) return;
+    const file = entry.originalFile;
+    uppy.removeFile(entry.id);
+    queue.value.splice(idx, 1);
+    const newId = addFile(file, trimmed);
+    if (!newId) return;
+    const newIdx = findQueueEntryIndexById(newId);
+    if (newIdx !== -1 && newIdx !== idx) {
+      const moved = queue.value.splice(newIdx, 1)[0];
+      if (moved) queue.value.splice(idx, 0, moved);
+    }
   };
 
   onMounted(() => {
@@ -354,5 +410,6 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
     getClassNameForEntry,
     getIconForEntry,
     addExternalFiles,
+    renameEntry,
   };
 }


### PR DESCRIPTION
## Summary

Adds an inline rename action on each row of the upload dialog's file queue:

- A pencil button on every queue row swaps the file name display for an editable input with save (✓) and cancel (✗) controls. `Enter` saves, `Esc` cancels. The basename (without extension) is preselected so the user can type immediately.
- **Pending / error / canceled** entries are renamed **locally**: the file is removed from Uppy and re-added under the new name at the same queue position, so the server receives the chosen name on upload.
- **Completed** entries call `adapter.rename({ path, item, name })` against the upload target folder, then invalidate the listing (and reopen it if the user is currently viewing that folder).
- Folder uploads (entries like `sub/file.txt`) keep their subfolder prefix — only the basename portion is edited.
- The rename button is disabled while a file is uploading or while the overall queue is uploading.

## Files

- `src/composables/useUpload.ts` — new `renameEntry(entry, newName)` exposed from the composable; chooses local rename vs `adapter.rename` based on entry status.
- `src/components/modals/ModalUpload.vue` — inline edit state (`editingId`, `editingName`, `renameInputRef`) and the row template changes.
- `src/assets/css/components/modals/_modal_upload.css` — styles for the rename action button, input, and save/cancel buttons.

## Test plan

- [ ] Open the upload modal, pick a file, click the pencil → edit name → save. Click Upload and confirm the server receives the renamed file.
- [ ] Repeat for a file that finished uploading (status: Done) and confirm `adapter.rename` is called and the listing refreshes.
- [ ] Try renaming during an active upload — the action should be disabled.
- [ ] Drag a folder onto the dialog (folder upload) and confirm the rename input only edits the basename, preserving the subfolder prefix.
- [ ] Press `Esc` while editing — the row reverts without changes.
- [ ] Confirm the mobile layout (narrow viewport) still fits the new button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)