### PR TITLE
Release 4.5.2

### DIFF
--- a/dist/CodeMirrorEditor-I8Cyd6Sk.js
+++ b/dist/CodeMirrorEditor-I8Cyd6Sk.js
@@ -1,5 +1,5 @@
 import { defineComponent as Th, ref as Cr, onMounted as Oh, watch as In, onBeforeUnmount as Bh, openBlock as Eh, createElementBlock as Lh, createElementVNode as Ar, unref as Nn, normalizeClass as Mr, createStaticVNode as Ph } from "vue";
-import { u as Rh } from "./index-DKfDIDxR.js";
+import { u as Rh } from "./index-dm9K-vRJ.js";
 let os = [], Xo = [];
 (() => {
   let s = "lc,34,7n,7,7b,19,,,,2,,2,,,20,b,1c,l,g,,2t,7,2,6,2,2,,4,z,,u,r,2j,b,1m,9,9,,o,4,,9,,3,,5,17,3,3b,f,,w,1j,,,,4,8,4,,3,7,a,2,t,,1m,,,,2,4,8,,9,,a,2,q,,2,2,1l,,4,2,4,2,2,3,3,,u,2,3,,b,2,1l,,4,5,,2,4,,k,2,m,6,,,1m,,,2,,4,8,,7,3,a,2,u,,1n,,,,c,,9,,14,,3,,1l,3,5,3,,4,7,2,b,2,t,,1m,,2,,2,,3,,5,2,7,2,b,2,s,2,1l,2,,,2,4,8,,9,,a,2,t,,20,,4,,2,3,,,8,,29,,2,7,c,8,2q,,2,9,b,6,22,2,r,,,,,,1j,e,,5,,2,5,b,,10,9,,2u,4,,6,,2,2,2,p,2,4,3,g,4,d,,2,2,6,,f,,jj,3,qa,3,t,3,t,2,u,2,1s,2,,7,8,,2,b,9,,19,3,3b,2,y,,3a,3,4,2,9,,6,3,63,2,2,,1m,,,7,,,,,2,8,6,a,2,,1c,h,1r,4,1c,7,,,5,,14,9,c,2,w,4,2,2,,3,1k,,,2,3,,,3,1m,8,2,2,48,3,,d,,7,4,,6,,3,2,5i,1m,,5,ek,,5f,x,2da,3,3x,,2o,w,fe,6,2x,2,n9w,4,,a,w,2,28,2,7k,,3,,4,,p,2,5,,47,2,q,i,d,,12,8,p,b,1a,3,1c,,2,4,2,2,13,,1v,6,2,2,2,2,c,,8,,1b,,1f,,,3,2,2,5,2,,,16,2,8,,6m,,2,,4,,fn4,,kh,g,g,g,a6,2,gt,,6a,,45,5,1ae,3,,2,5,4,14,3,4,,4l,2,fx,4,ar,2,49,b,4w,,1i,f,1k,3,1d,4,2,2,1x,3,10,5,,8,1q,,c,2,1g,9,a,4,2,,2n,3,2,,,2,6,,4g,,3,8,l,2,1l,2,,,,,m,,e,7,3,5,5f,8,2,3,,,n,,29,,2,6,,,2,,,2,,2,6j,,2,4,6,2,,2,r,2,2d,8,2,,,2,2y,,,,2,6,,,2t,3,2,4,,5,77,9,,2,6t,,a,2,,,4,,40,4,2,2,4,,w,a,14,6,2,4,8,,9,6,2,3,1a,d,,2,ba,7,,6,,,2a,m,2,7,,2,,2,3e,6,3,,,2,,7,,,20,2,3,,,,9n,2,f0b,5,1n,7,t4,,1r,4,29,,f5k,2,43q,,,3,4,5,8,8,2,7,u,4,44,3,1iz,1j,4,1e,8,,e,,m,5,,f,11s,7,,h,2,7,,2,,5,79,7,c5,4,15s,7,31,7,240,5,gx7k,2o,3k,6o".split(",").map((e) => e ? parseInt(e, 36) : 1);
@@ -14490,29 +14490,29 @@ const ug = /* @__PURE__ */ O.baseTheme({
         case "json":
         case "jsonc":
         case "lock": {
-          const { json: k } = await import("./index-ClI-RYT2.js");
+          const { json: k } = await import("./index-AsSdN75W.js");
           C = k();
           break;
         }
         case "js":
         case "mjs":
         case "cjs": {
-          const { javascript: k } = await import("./index-CGHlit_l.js").then((W) => W.i);
+          const { javascript: k } = await import("./index-Dz5J6Tkc.js").then((W) => W.i);
           C = k();
           break;
         }
         case "jsx": {
-          const { javascript: k } = await import("./index-CGHlit_l.js").then((W) => W.i);
+          const { javascript: k } = await import("./index-Dz5J6Tkc.js").then((W) => W.i);
           C = k({ jsx: !0 });
           break;
         }
         case "ts": {
-          const { javascript: k } = await import("./index-CGHlit_l.js").then((W) => W.i);
+          const { javascript: k } = await import("./index-Dz5J6Tkc.js").then((W) => W.i);
           C = k({ typescript: !0 });
           break;
         }
         case "tsx": {
-          const { javascript: k } = await import("./index-CGHlit_l.js").then((W) => W.i);
+          const { javascript: k } = await import("./index-Dz5J6Tkc.js").then((W) => W.i);
           C = k({ typescript: !0, jsx: !0 });
           break;
         }
@@ -14520,7 +14520,7 @@ const ug = /* @__PURE__ */ O.baseTheme({
         case "svelte":
         case "html":
         case "htm": {
-          const { html: k } = await import("./index-DHTj5biS.js");
+          const { html: k } = await import("./index-Dnh1Eq-B.js");
           C = k();
           break;
         }
@@ -14528,25 +14528,25 @@ const ug = /* @__PURE__ */ O.baseTheme({
         case "scss":
         case "sass":
         case "less": {
-          const { css: k } = await import("./index-DqYmpa55.js");
+          const { css: k } = await import("./index-BrU_Tp7n.js");
           C = k();
           break;
         }
         case "md":
         case "markdown": {
-          const { markdown: k } = await import("./index-CVXickBg.js");
+          const { markdown: k } = await import("./index-CXYBSsQ_.js");
           C = k();
           break;
         }
         case "yml":
         case "yaml": {
-          const { yaml: k } = await import("./index-CayWWBxm.js");
+          const { yaml: k } = await import("./index-8aZl9FYm.js");
           C = k();
           break;
         }
         case "xml":
         case "svg": {
-          const { xml: k } = await import("./index-BTbtS_RT.js");
+          const { xml: k } = await import("./index-BGboYL-P.js");
           C = k();
           break;
         }

--- a/dist/index-8aZl9FYm.js
+++ b/dist/index-8aZl9FYm.js
@@ -1,5 +1,5 @@
-import { L as V, E as i, C as _ } from "./index-BGoNEumZ.js";
-import { J as w, Q as P, f as Z, L, y as B, t as v, w as E, v as M } from "./CodeMirrorEditor-B-S-0evY.js";
+import { L as V, E as i, C as _ } from "./index-Bjx_hv7C.js";
+import { J as w, Q as P, f as Z, L, y as B, t as v, w as E, v as M } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 const f = 63, q = 64, j = 1, A = 2, U = 3, H = 4, W = 5, N = 6, I = 7, y = 65, u = 66, F = 8, K = 9, J = 10, OO = 11, eO = 12, Y = 13, aO = 19, rO = 20, QO = 29, PO = 33, tO = 34, oO = 47, nO = 0, $ = 1, b = 2, d = 3, g = 4;
 class s {
   constructor(e, a, r) {

--- a/dist/index-AsSdN75W.js
+++ b/dist/index-AsSdN75W.js
@@ -1,5 +1,5 @@
-import { L as r } from "./index-BGoNEumZ.js";
-import { J as a, Q as O, f as P, L as Q, y as s, q as e, w as o, v as t } from "./CodeMirrorEditor-B-S-0evY.js";
+import { L as r } from "./index-Bjx_hv7C.js";
+import { J as a, Q as O, f as P, L as Q, y as s, q as e, w as o, v as t } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 const n = a({
   String: O.string,
   Number: O.number,

--- a/dist/index-BGboYL-P.js
+++ b/dist/index-BGboYL-P.js
@@ -1,5 +1,5 @@
-import { L as G, E as A, C as N } from "./index-BGoNEumZ.js";
-import { J as I, Q as p, f as Y, L as j, y as U, w as Z, p as B, O as k, c as D, E as M } from "./CodeMirrorEditor-B-S-0evY.js";
+import { L as G, E as A, C as N } from "./index-Bjx_hv7C.js";
+import { J as I, Q as p, f as Y, L as j, y as U, w as Z, p as B, O as k, c as D, E as M } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 const h = 1, F = 2, L = 3, J = 4, K = 5, H = 36, ee = 37, te = 38, Oe = 11, oe = 13;
 function re(e) {
   return e == 45 || e == 46 || e == 58 || e >= 65 && e <= 90 || e == 95 || e >= 97 && e <= 122 || e >= 161;

--- a/dist/index-Bjx_hv7C.js
+++ b/dist/index-Bjx_hv7C.js
@@ -1,4 +1,4 @@
-import { j as M, g as L, h as $, a as E, N as y, o as S, I as j } from "./CodeMirrorEditor-B-S-0evY.js";
+import { j as M, g as L, h as $, a as E, N as y, o as S, I as j } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 class v {
   /**
   @internal

--- a/dist/index-BrU_Tp7n.js
+++ b/dist/index-BrU_Tp7n.js
@@ -1,5 +1,5 @@
-import { L as k, E as $, a as z } from "./index-BGoNEumZ.js";
-import { J as R, Q as t, f as Y, L as W, y as Z, q as x, w as G, v as _, O as V, i as E, I as U } from "./CodeMirrorEditor-B-S-0evY.js";
+import { L as k, E as $, a as z } from "./index-Bjx_hv7C.js";
+import { J as R, Q as t, f as Y, L as W, y as Z, q as x, w as G, v as _, O as V, i as E, I as U } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 const T = 135, m = 1, q = 136, C = 137, P = 2, N = 138, F = 3, I = 4, X = [
   9,
   10,

--- a/dist/index-CXYBSsQ_.js
+++ b/dist/index-CXYBSsQ_.js
@@ -1,6 +1,6 @@
-import { j as st, h as Q, N as v, T as it, g as Ee, J as Ie, o as H, H as ot, Q as m, f as fe, k as at, B as lt, x as ht, O as X, E as P, r as z, d as ft, z as ut, s as dt, b as pt, w as Me, y as ct, G as mt, c as gt, e as ue, P as kt } from "./CodeMirrorEditor-B-S-0evY.js";
-import { C as Lt } from "./index-CGHlit_l.js";
-import { html as bt, htmlCompletionSource as wt } from "./index-DHTj5biS.js";
+import { j as st, h as Q, N as v, T as it, g as Ee, J as Ie, o as H, H as ot, Q as m, f as fe, k as at, B as lt, x as ht, O as X, E as P, r as z, d as ft, z as ut, s as dt, b as pt, w as Me, y as ct, G as mt, c as gt, e as ue, P as kt } from "./CodeMirrorEditor-I8Cyd6Sk.js";
+import { C as Lt } from "./index-Dz5J6Tkc.js";
+import { html as bt, htmlCompletionSource as wt } from "./index-Dnh1Eq-B.js";
 class U {
   static create(e, r, n, s, i) {
     let o = s + (s << 8) + e + (r << 4) | 0;

--- a/dist/index-Dnh1Eq-B.js
+++ b/dist/index-Dnh1Eq-B.js
@@ -1,7 +1,7 @@
-import { L as be, E as $, C as he } from "./index-BGoNEumZ.js";
-import { H as Te, J as Pe, Q as b, f as xe, L as Ve, y as ye, w as we, p as ve, c as Xe, O as K, E as $e } from "./CodeMirrorEditor-B-S-0evY.js";
-import { cssLanguage as J, css as _e } from "./index-DqYmpa55.js";
-import { c as qe, b as Ce, t as ke, a as M, j as Qe } from "./index-CGHlit_l.js";
+import { L as be, E as $, C as he } from "./index-Bjx_hv7C.js";
+import { H as Te, J as Pe, Q as b, f as xe, L as Ve, y as ye, w as we, p as ve, c as Xe, O as K, E as $e } from "./CodeMirrorEditor-I8Cyd6Sk.js";
+import { cssLanguage as J, css as _e } from "./index-BrU_Tp7n.js";
+import { c as qe, b as Ce, t as ke, a as M, j as Qe } from "./index-Dz5J6Tkc.js";
 const Ae = 55, Ye = 1, Me = 56, Re = 2, Ee = 57, Ze = 3, z = 4, Be = 5, R = 6, ee = 7, te = 8, ae = 9, le = 10, ze = 11, De = 12, We = 13, _ = 58, Ne = 14, Ge = 15, D = 59, re = 21, Ie = 23, ne = 24, je = 25, A = 27, se = 28, Ue = 29, Le = 32, Fe = 35, He = 37, Ke = 38, Je = 0, et = 1, tt = {
   area: !0,
   base: !0,

--- a/dist/index-Dz5J6Tkc.js
+++ b/dist/index-Dz5J6Tkc.js
@@ -1,5 +1,5 @@
-import { L as lO, E as f, a as v, C as $O } from "./index-BGoNEumZ.js";
-import { J as nO, Q, O as u, n as oO, m as sO, S as b, z as cO, A as pO, E as w, D as x, l as ZO, c as T, k as PO, B as SO, M as G, W as XO, F as gO, R as mO, f as fO, K as C, L as dO, y as uO, u as xO, q as _, t as TO, w as YO, v as _O, s as kO, i as wO, I as yO } from "./CodeMirrorEditor-B-S-0evY.js";
+import { L as lO, E as f, a as v, C as $O } from "./index-Bjx_hv7C.js";
+import { J as nO, Q, O as u, n as oO, m as sO, S as b, z as cO, A as pO, E as w, D as x, l as ZO, c as T, k as PO, B as SO, M as G, W as XO, F as gO, R as mO, f as fO, K as C, L as dO, y as uO, u as xO, q as _, t as TO, w as YO, v as _O, s as kO, i as wO, I as yO } from "./CodeMirrorEditor-I8Cyd6Sk.js";
 const hO = 316, bO = 317, V = 1, zO = 2, jO = 3, qO = 4, RO = 318, WO = 320, vO = 321, GO = 5, VO = 6, UO = 0, y = [
   9,
   10,

--- a/dist/index-dm9K-vRJ.js
+++ b/dist/index-dm9K-vRJ.js
@@ -234,7 +234,7 @@ function hn() {
 function Un(s) {
   return s ? s === "simple" || s === "advanced" ? { ...Vn[s] } : { ...hn(), ...s } : hn();
 }
-const Uo = "4.5.1";
+const Uo = "4.5.2";
 function Qt(s, e, t, n, i) {
   return e = Math, t = e.log, n = 1024, i = t(s) / t(n) | 0, (s / e.pow(n, i)).toFixed(0) + " " + (i ? "KMGTPEZY"[--i] + "iB" : "B");
 }
@@ -2187,7 +2187,7 @@ const ra = { class: "vuefinder__text-preview" }, da = { class: "vuefinder__text-
   emits: ["success"],
   setup(s, { emit: e }) {
     const t = On({
-      loader: () => import("./CodeMirrorEditor-B-S-0evY.js").then((f) => f.C),
+      loader: () => import("./CodeMirrorEditor-I8Cyd6Sk.js").then((f) => f.C),
       delay: 100
     }), n = e, i = I(""), l = I(""), d = I(!1), r = I(!1), u = ie(), v = Re(u), { enabled: y } = ze(), { t: g } = u.i18n;
     we(async () => {
@@ -2279,7 +2279,7 @@ const ra = { class: "vuefinder__text-preview" }, da = { class: "vuefinder__text-
   emits: ["success"],
   setup(s, { emit: e }) {
     const t = On({
-      loader: () => import("./CodeMirrorEditor-B-S-0evY.js").then((Z) => Z.C),
+      loader: () => import("./CodeMirrorEditor-I8Cyd6Sk.js").then((Z) => Z.C),
       delay: 100
     }), n = e, i = I(""), l = I(""), d = ut([]), r = ut([]), u = I(null), v = I(!1), y = I(!1), g = z(() => d.value.length > Nt), p = z(() => g.value ? d.value.slice(0, Nt) : d.value), k = ie(), b = Re(k), { enabled: $ } = ze(), { t: m } = k.i18n;
     async function h(Z) {
@@ -10185,6 +10185,8 @@ const mo = [
       t("delete-complete", f);
     }), i.emitter.on("vf-notify", (f) => {
       t("notify", f);
+      const { type: S, message: C } = f ?? {};
+      S === "error" && t("error", C);
     }), i.emitter.on("vf-file-dclick", (f) => {
       t("file-dclick", f);
     }), i.emitter.on("vf-folder-dclick", (f) => {

--- a/dist/types/adapters/types.d.ts
+++ b/dist/types/adapters/types.d.ts
@@ -50,7 +50,7 @@ export interface DeleteResult extends FileOperationResult {
  */
 export interface FileOperationResult {
     files: DirEntry[];
-    storages: Storage[];
+    storages: string[];
     read_only: boolean;
     dirname: string;
 }

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -18,6 +18,8 @@ export { useVueFinder };
 export { RemoteDriver, ArrayDriver, IndexedDBDriver, BaseAdapter, parseBackendError };
 export type { DirEntry, ItemDclickEvent, VueFinderProps, FsData, SelectEvent, UpdatePathEvent, NotifyEvent, NotifyPayload, VueFinderComposable, } from './types';
 export type { Item } from './utils/contextmenu';
+export type { ArrayDriverConfig } from './adapters/ArrayDriver';
+export type { IndexedDBDriverConfig } from './adapters/IndexedDBDriver';
 export type { Driver, ListParams, DeleteParams, RenameParams, TransferParams, ArchiveParams, UnarchiveParams, SearchParams, SaveParams, FileContentResult, DeleteResult, FileOperationResult, RemoteDriverConfig, RemoteDriverUrls, UploaderContext, } from './adapters/types';
 export type { FeaturesConfig, FeaturesPreset, FeatureName } from './features';
 export type { ConfigStore, ConfigState, ConfigDefaults, PersistenceConfigState, NonPersistenceConfigState, } from './stores/config';

--- a/dist/vuefinder.js
+++ b/dist/vuefinder.js
@@ -1,4 +1,4 @@
-import { A as s, B as t, C as d, I as n, R as i, _ as o, V as u, _ as m, m as V, c, V as p, p as v, a as x } from "./index-DKfDIDxR.js";
+import { A as s, B as t, C as d, I as n, R as i, _ as o, V as u, _ as m, m as V, c, V as p, p as v, a as x } from "./index-dm9K-vRJ.js";
 import "vue";
 export {
   s as ArrayDriver,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -153,7 +153,7 @@ gtag('config', 'G-6BYQESCJ6R');`
         },
         license: 'https://opensource.org/licenses/MIT',
         codeRepository: 'https://github.com/n1crack/vuefinder',
-        softwareVersion: '4.0.15',
+        softwareVersion: '4.5.1',
         programmingLanguage: 'TypeScript',
         runtimePlatform: 'Vue.js 3'
       })

--- a/docs/api-reference/drivers-interface.md
+++ b/docs/api-reference/drivers-interface.md
@@ -213,6 +213,7 @@ Copy one or more files or folders to a destination path.
 - `params: TransferParams` - Required parameters object
   - `sources: string[]` - Array of full paths to items to copy (including storage prefix)
   - `destination: string` - Full destination path where items should be copied to
+  - `path?: string` - Optional current directory path (used to refresh the listing after the operation)
 
 **Returns:** `Promise<FileOperationResult>` - Promise resolving to operation result:
   - `files: DirEntry[]` - Updated file list after copy operation
@@ -249,6 +250,7 @@ Move (cut) one or more files or folders to a destination path.
 - `params: TransferParams` - Required parameters object
   - `sources: string[]` - Array of full paths to items to move (including storage prefix)
   - `destination: string` - Full destination path where items should be moved to
+  - `path?: string` - Optional current directory path (used to refresh the listing after the operation)
 
 **Returns:** `Promise<FileOperationResult>` - Promise resolving to operation result:
   - `files: DirEntry[]` - Updated file list after move operation

--- a/docs/api-reference/events.md
+++ b/docs/api-reference/events.md
@@ -15,7 +15,7 @@ Complete reference of all VueFinder events.
 | `upload-complete` | `DirEntry[]` | Emitted when upload completes         |
 | `delete-complete` | `DirEntry[]` | Emitted when deletion completes       |
 | `notify`          | `NotifyPayload` | Emitted when VueFinder creates a notification |
-| `error`           | `any`        | Emitted when an error occurs          |
+| `error`           | `string`     | Emitted when an operation fails (error message) |
 | `ready`           | -            | Emitted when component is ready       |
 | `file-dclick`     | `ItemDclickEvent` | Emitted when file is double-clicked   |
 | `folder-dclick`   | `ItemDclickEvent` | Emitted when folder is double-clicked |
@@ -88,16 +88,16 @@ const handleDeleteComplete = (deletedItems) => {
 
 ### `error`
 
-Emitted when an error occurs during any operation.
+Emitted when an operation fails. This fires alongside `notify` for every error-type notification, so you can react to failures without filtering `notify` payloads yourself.
 
-**Payload:** `any` - Error object or message
+**Payload:** `string` - Error message
 
 ```vue
 <vue-finder @error="handleError" />
 
 <script setup>
-const handleError = (error) => {
-  console.error('Error:', error);
+const handleError = (message) => {
+  console.error('Error:', message);
 };
 </script>
 ```

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -227,7 +227,6 @@ components:
       required:
         - sources
         - destination
-        - path
       properties:
         sources:
           type: array
@@ -241,7 +240,7 @@ components:
           example: "local://backup"
         path:
           type: string
-          description: Current directory path (including storage prefix)
+          description: Optional current directory path (including storage prefix), used to refresh the listing after the operation
           example: "local://uploads"
 
     ArchiveRequest:
@@ -345,13 +344,13 @@ paths:
       tags:
         - Files
       summary: List files and folders
-      description: List files and folders in a directory at the specified path. The path parameter is required and should include the storage prefix.
+      description: List files and folders in a directory at the specified path. The path should include the storage prefix; when omitted, the backend lists the default storage root.
       operationId: listFiles
       parameters:
         - name: path
           in: query
-          required: true
-          description: Directory path to list (including storage prefix, e.g., "local://uploads")
+          required: false
+          description: Directory path to list (including storage prefix, e.g., "local://uploads"). Defaults to the storage root when omitted.
           schema:
             type: string
           example: "local://uploads"
@@ -411,11 +410,16 @@ paths:
               type: object
               required:
                 - file
+                - path
               properties:
                 file:
                   type: string
                   format: binary
                   description: File to upload
+                path:
+                  type: string
+                  description: Target directory path (including storage prefix)
+                  example: "local://uploads"
       responses:
         '200':
           description: Files uploaded successfully. Returns empty JSON response.

--- a/docs/api-reference/types.md
+++ b/docs/api-reference/types.md
@@ -123,6 +123,7 @@ export interface ArrayDriverConfig {
   storage?: string;
   storages?: string[];
   readOnly?: boolean;
+  contentStore?: Map<string, string | ArrayBuffer>;
 }
 ```
 
@@ -130,6 +131,7 @@ export interface ArrayDriverConfig {
 
 - `storage` is the default storage prefix used when a path does not specify one.
 - `storages` enables multi-storage mode for ArrayDriver.
+- `contentStore` optionally pre-seeds file contents keyed by full path; it is also where edited/uploaded contents are kept in memory.
 
 ### `IndexedDBDriverConfig`
 

--- a/docs/examples/context-menu.md
+++ b/docs/examples/context-menu.md
@@ -52,7 +52,7 @@ const customMenuItems = [
 The `contextMenuItems` prop allows you to add custom items to the right-click context menu:
 
 - **`id`**: Unique identifier for the menu item (required)
-- **`title`**: Function that returns the display text, receives i18n object: `(i18n) => string`
+- **`title`**: Function that returns the display text, receives i18n object: `(i18n) => string`. For translated labels use `title: ({ t }) => t('Custom Action')` — built-in items do this; a plain `() => 'Custom Action'` also works but skips translation
 - **`action`**: Function called when the item is clicked, receives `(app, selectedItems)` as parameters
 - **`show`**: Function that determines if the item should be displayed, receives `(app, ctx)` as parameters, returns `boolean`
 - **`link`**: Optional function that returns a URL for link-style menu items (download, etc.)

--- a/docs/examples/external-selection.md
+++ b/docs/examples/external-selection.md
@@ -23,7 +23,7 @@ Example showing how to handle selection externally using the `@select` event.
       <h3>Selected Items ({{ selectedItems.length }})</h3>
       <ul>
         <li v-for="item in selectedItems" :key="item.path">
-          {{ item.name }}
+          {{ item.basename }}
         </li>
       </ul>
       <button @click="processSelection">Process Selection</button>

--- a/docs/examples/notifications.md
+++ b/docs/examples/notifications.md
@@ -63,6 +63,33 @@ Example showing how to:
     </div>
   </div>
 </template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { RemoteDriver } from 'vuefinder';
+
+const driver = new RemoteDriver({ baseURL: '/api' });
+
+const notificationsEnabled = ref(true);
+const notificationPosition = ref('bottom-center');
+const notificationDuration = ref(3000);
+const notifyEvents = ref([]);
+
+const config = computed(() => ({
+  notificationsEnabled: notificationsEnabled.value,
+  notificationPosition: notificationPosition.value,
+  notificationDuration: Number(notificationDuration.value) || 3000,
+}));
+
+const handleNotify = ({ type, message }) => {
+  notifyEvents.value.unshift({ type, message, at: new Date().toLocaleTimeString() });
+  notifyEvents.value = notifyEvents.value.slice(0, 20);
+};
+
+const clearNotifyEvents = () => {
+  notifyEvents.value = [];
+};
+</script>
 ```
 
 ## Notes

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,6 +6,11 @@ outline: deep
 
 VueFinder is a file manager component for Vue.js version 3. Follow these steps to get started.
 
+## Requirements
+
+- **Vue** `^3.5`
+- **Node.js** `^20.19.0 || >=22.12.0` (for building/development)
+
 ## Install via npm
 
 ```bash

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -19,7 +19,7 @@ Easily integrate it into your app, connect to any storage (local, S3, etc.), and
 - **Production-ready file manager** — Full-featured, ready for production
 - **Zero backend lock-in** — Works with any backend (PHP, Node.js, Python, Go, Rust, etc.)
 - **Built-in text editor** — Edit files directly in the browser
-- **Image crop tool** — Built-in image cropping and editing
+- **Image editor** — Built-in multi-tool editor with Crop, Rotate, Grayscale, and Adjust (brightness / contrast / saturation)
 - **Multi-format preview** — Preview images, videos, audio, PDFs, and text files
 - **Deep search** — Recursive folder search with filters
 - **Archive management** — Create and extract ZIP archives
@@ -62,11 +62,11 @@ Easily integrate it into your app, connect to any storage (local, S3, etc.), and
 
 ## Version
 
-**Current Version:** 4.0
+**Current Version:** 4.x — see [releases](https://github.com/n1crack/vuefinder/releases) for the latest version.
 
 ::: info Version Note
 
-Version 3.0 was skipped for organizational reasons. VueFinder 4.0 represents a significant evolution of the library with a driver-based architecture, enhanced features system, and improved TypeScript support.
+Version 3.0 was skipped for organizational reasons. VueFinder 4.x represents a significant evolution of the library with a driver-based architecture, enhanced features system, and improved TypeScript support.
 
 :::
 
@@ -75,7 +75,7 @@ Version 3.0 was skipped for organizational reasons. VueFinder 4.0 represents a s
 - **Vue 3 Compatible** - Built from the ground up for Vue 3
 - **TypeScript Support** - Comprehensive type definitions included
 - **Multiple Themes** - 12 beautiful themes: silver, valorite, midnight, latte, rose, mythril, lime, sky, ocean, palenight, arctic, code
-- **Multi-language Support** - 17 languages: en, tr, ru, de, es, fr, it, ja, nl, pl, pt, sv, ar, fa, he, hi, zhCN, zhTW
+- **Multi-language Support** - 18 languages: en, tr, ru, de, es, fr, it, ja, nl, pl, pt, sv, ar, fa, he, hi, zhCN, zhTW
 - **Flexible Features System** - Enable or disable features as needed
 - **Local and Remote Drivers** - Support for both in-memory and HTTP API backends
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -51,9 +51,9 @@ const driver = new RemoteDriver({
 
 ## Backend Requirements
 
-VueFinder requires a backend that implements the VueFinder API. For VueFinder 4.0, the following backend is supported:
+VueFinder requires a backend that implements the VueFinder API. For VueFinder 4.x, the following backend is supported:
 
-- **PHP**: [VueFinder PHP Library 4.0](https://github.com/n1crack/vuefinder-php) - Official backend for VueFinder 4.0
+- **PHP**: [VueFinder PHP Library](https://github.com/n1crack/vuefinder-php) - Official backend for VueFinder 4.x
 
 ## Essential Props
 

--- a/docs/guide/composable-api.md
+++ b/docs/guide/composable-api.md
@@ -45,6 +45,51 @@ const testNotify = () => {
 </template>
 ```
 
+## All Methods
+
+`useVueFinder(id)` returns a `VueFinderComposable` with the following methods:
+
+### Navigation & state
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `refresh` | `() => Promise<void>` | Reload the current directory |
+| `open` | `(path: string) => Promise<void>` | Navigate to a path |
+| `getPath` | `() => string` | Current directory path |
+| `getFiles` | `() => DirEntry[]` | Entries in the current directory |
+| `getStorages` | `() => string[]` | Available storage names |
+| `isLoading` | `() => boolean` | Whether a request is in flight |
+| `isReadOnly` | `() => boolean` | Whether the current directory is read-only |
+
+### Selection
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `select` | `(paths: string[]) => void` | Select the given paths |
+| `selectOne` | `(path: string) => void` | Select a single path |
+| `clearSelection` | `() => void` | Clear the selection |
+| `getSelectedPaths` | `() => string[]` | Paths of the selected items |
+
+### File operations
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `createFolder` | `(name: string, path?: string) => Promise<void>` | Create a folder (in `path` or the current directory) |
+| `createFile` | `(name: string, path?: string) => Promise<void>` | Create an empty file |
+| `delete` | `(paths: string[], path?: string) => Promise<void>` | Delete items |
+| `rename` | `(itemPath: string, newName: string, path?: string) => Promise<void>` | Rename an item |
+| `copy` | `(sources: string[], destination: string, path?: string) => Promise<void>` | Copy items to a destination folder |
+| `move` | `(sources: string[], destination: string, path?: string) => Promise<void>` | Move items to a destination folder |
+
+### UI
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `preview` | `(path: string) => void` | Open the preview modal for a file |
+| `notify` | `(type, message) => void` | Show a notification (`type`: `'success' \| 'error' \| 'info' \| 'warning'`) |
+
+See [API Reference – Types](../api-reference/types.md#vuefindercomposable) for the full interface definition.
+
 ## Notes
 
 - The target instance **must be mounted**. If not, `useVueFinder(id)` throws a descriptive error.

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -82,7 +82,7 @@ const handleDeleteComplete = (deletedItems) => {
 
 ### `@error`
 
-Emitted when an error occurs during any operation:
+Emitted when an operation fails. It fires alongside `@notify` for every error-type notification:
 
 ```vue
 <template>
@@ -90,13 +90,13 @@ Emitted when an error occurs during any operation:
 </template>
 
 <script setup>
-const handleError = (error) => {
-  console.error('VueFinder error:', error);
+const handleError = (message) => {
+  console.error('VueFinder error:', message);
 };
 </script>
 ```
 
-**Payload:** `any` - Error object
+**Payload:** `string` - Error message
 
 ### `@notify`
 
@@ -256,8 +256,8 @@ const handleNotify = ({ type, message }) => {
   console.log('Notify:', type, message);
 };
 
-const handleError = (error) => {
-  console.error('Error:', error);
+const handleError = (message) => {
+  console.error('Error:', message);
 };
 
 const handleReady = () => {

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -78,7 +78,7 @@ If a file's reported MIME type doesn't match its extension, VueFinder falls back
 
 ### Table view for CSV / TSV
 
-`.csv` and `.tsv` files open as text by default. The preview header has a **Table** toggle next to **Edit** — clicking it renders the file as a real table with a sticky header row and a sticky row-number column. The delimiter (`,`, `;`, `\t`, `|`) is auto-detected. Files larger than 1,000 rows show a "first 1,000 shown" note; the text view still has all rows.
+`.csv` and `.tsv` files open as text by default. A **Show as table** checkbox at the bottom of the CSV panel renders the file as a real table with a sticky header row and a sticky row-number column (the checkbox is hidden in edit mode). The delimiter (`,`, `;`, `\t`, `|`) is auto-detected. Files larger than 1,000 rows show a "first 1,000 shown" note; the text view still has all rows.
 
 Papaparse is loaded as its own lazy chunk on the first Table-view open.
 
@@ -93,6 +93,23 @@ The image previewer has a floating toolbar in the bottom-right with zoom in / zo
 - Mouse-wheel to zoom
 - `+` / `-` / `0` keyboard shortcuts
 - Click-and-drag to pan when zoomed in
+
+### Image editor
+
+Images can be edited in place via a multi-tool editor with four tabs:
+
+- **Crop** — select and crop a region of the image.
+- **Rotate** — rotate the image.
+- **Grayscale** — convert the image to grayscale.
+- **Adjust** — brightness / contrast / saturation sliders.
+
+The edited result is saved back through the driver, so it works with any backend that supports `save`.
+
+## Navigation
+
+### Go to Folder
+
+The **Go** menu in the menubar includes a **Go to Folder** action that opens a path-input modal with autocomplete: as you type, storage names and matching subfolders of the typed path are suggested, and you can navigate the suggestion list with the keyboard.
 
 ## Search
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -8,7 +8,7 @@ VueFinder supports multiple languages and provides easy ways to customize transl
 
 ## Built-in Languages
 
-VueFinder comes with 17 built-in language packs:
+VueFinder comes with 18 built-in language packs:
 
 - **English (en)** - Default language
 - **Turkish (tr)** - Türkçe

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ features:
   - title: 🎨 Beautiful Modern Interface
     details: Polished UI with context menus, breadcrumbs, thumbnails, and responsive design that works perfectly on desktop and mobile.
   - title: ⚡ Developer-Friendly
-    details: TypeScript support, 17 languages, 12 themes, flexible configuration, and easy backend integration. Built for Vue 3.
+    details: TypeScript support, 18 languages, 12 themes, flexible configuration, and easy backend integration. Built for Vue 3.
 ---
 
 <ClientOnly>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vuefinder",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuefinder",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefinder",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A sleek, developer-friendly file manager for Vue — organize, preview, and manage files with ease.",
   "type": "module",
   "engines": {

--- a/src/adapters/ArrayDriver.ts
+++ b/src/adapters/ArrayDriver.ts
@@ -250,7 +250,7 @@ export class ArrayDriver extends BaseAdapter {
       storages: this.storages,
       read_only: this.readOnly,
       dirname: dirnameFull,
-    } as unknown as FileOperationResult;
+    };
   }
 
   async list(params?: ListParams): Promise<FsData> {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -57,7 +57,7 @@ export interface DeleteResult extends FileOperationResult {
  */
 export interface FileOperationResult {
   files: DirEntry[];
-  storages: Storage[];
+  storages: string[];
   read_only: boolean;
   dirname: string;
 }

--- a/src/components/VueFinderView.vue
+++ b/src/components/VueFinderView.vue
@@ -15,7 +15,7 @@ import Statusbar from '../components/Statusbar.vue';
 import TreeView from '../components/TreeView.vue';
 import ModalUpload from '../components/modals/ModalUpload.vue';
 import { menuItems as contextMenuItems } from '../utils/contextmenu';
-import type { VueFinderProps, DirEntry } from '../types';
+import type { VueFinderProps, DirEntry, NotifyPayload } from '../types';
 import type { FsData } from '../adapters/types';
 import type { StoreValue } from 'nanostores';
 import type { ConfigState } from '../stores/config';
@@ -123,6 +123,11 @@ app.emitter.on('vf-delete-complete', (deletedItems: unknown) => {
 
 app.emitter.on('vf-notify', (payload: unknown) => {
   emit('notify', payload);
+  // Surface error-type notifications through the dedicated 'error' event too
+  const { type, message } = (payload ?? {}) as NotifyPayload;
+  if (type === 'error') {
+    emit('error', message);
+  }
 });
 
 // Listen for custom double-click events

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,10 @@ export type {
 // Export context menu item type
 export type { Item } from './utils/contextmenu';
 
+// Export driver config types
+export type { ArrayDriverConfig } from './adapters/ArrayDriver';
+export type { IndexedDBDriverConfig } from './adapters/IndexedDBDriver';
+
 // Export types from adapters/types.ts
 export type {
   Driver,


### PR DESCRIPTION
## 4.5.2

### Fixes
- **`FileOperationResult.storages` type corrected** from `Storage[]` to `string[]` — the old type silently resolved to the DOM `Storage` interface (localStorage's type); every driver and consumer uses storage name strings. Also removed the `as unknown as FileOperationResult` cast in ArrayDriver that was suppressing the resulting type error.
- **`error` event now actually fires.** It was declared in `defineEmits` and documented, but never emitted. It now fires alongside `notify` for every error-type notification, so `@error` / `onError` handlers receive failures (payload: error message string).
- **`ArrayDriverConfig` and `IndexedDBDriverConfig` exported from package root** — the TypeScript docs already promised they were importable from `'vuefinder'`.

### Documentation accuracy pass
- Stale version references fixed (intro 4.0 → 4.x, SEO softwareVersion 4.0.15 → 4.5.1)
- Language pack count 17 → 18 across pages
- `external-selection` example used non-existent `item.name` → `item.basename`
- `notifications` example was template-only — added the missing `<script setup>`
- Composable API guide now documents all 19 `useVueFinder()` methods (was 4)
- Features guide: added 4.5.0 image editor (Crop/Rotate/Grayscale/Adjust) and Go to Folder autocomplete; CSV table toggle updated to the 4.5.1 bottom checkbox
- Installation: Vue/Node version requirements added
- Drivers interface: optional `path` param documented on copy/move
- Types: missing `contentStore` field added to `ArrayDriverConfig`
- OpenAPI: `path` optional on list/transfer (matches code), missing upload `path` field added
- Events docs aligned with the now-working `error` event