### PR TITLE
style(transfer): prettier formatting fix

### DIFF
--- a/src/components/modals/ModalTransfer.vue
+++ b/src/components/modals/ModalTransfer.vue
@@ -98,8 +98,7 @@ const invalidDestinationMessage = computed(() => {
   // Find which item is causing the conflict
   const conflictingItem = items.value.find((item: DirEntry) => {
     return (
-      dest.path === item.path ||
-      (item.type === 'dir' && dest.path.startsWith(item.path + '/'))
+      dest.path === item.path || (item.type === 'dir' && dest.path.startsWith(item.path + '/'))
     );
   });
 


### PR DESCRIPTION
CI on 4.5.5 went red on the Prettier check — `ModalTransfer.vue` had a two-line boolean expression Prettier wanted collapsed to one line. Formatting only, no behavior or version change.