### PR TITLE
Release 4.6.0: same-name selection fix, reactive path ref, OpenAPI alignment

### DIFF
--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -175,6 +175,22 @@ components:
           description: MIME type of the content
           example: "text/plain"
 
+    ItemReference:
+      type: object
+      description: Reference to a file or folder, used by delete and archive requests.
+      required:
+        - path
+        - type
+      properties:
+        path:
+          type: string
+          description: Full path to the item (including storage prefix)
+          example: "local://documents/file.txt"
+        type:
+          type: string
+          enum: [file, dir]
+          description: Item type
+
     DeleteRequest:
       type: object
       required:
@@ -187,20 +203,9 @@ components:
           example: "local://uploads"
         items:
           type: array
+          description: Items to delete
           items:
-            type: object
-            required:
-              - path
-              - type
-            properties:
-              path:
-                type: string
-                description: Full path to the item (including storage prefix)
-                example: "local://documents/file.txt"
-              type:
-                type: string
-                enum: [file, dir]
-                description: Item type
+            $ref: '#/components/schemas/ItemReference'
 
     RenameRequest:
       type: object
@@ -252,20 +257,9 @@ components:
       properties:
         items:
           type: array
-          items:
-            type: object
-            required:
-              - path
-              - type
-            properties:
-              path:
-                type: string
-                description: Full path to the item (including storage prefix)
-              type:
-                type: string
-                enum: [file, dir]
-                description: Item type
           description: Array of items to include in archive
+          items:
+            $ref: '#/components/schemas/ItemReference'
         path:
           type: string
           description: Directory path where archive should be created (including storage prefix)
@@ -274,6 +268,12 @@ components:
           type: string
           description: Name for the archive file (typically .zip)
           example: "archive.zip"
+        destination:
+          type: string
+          description: >-
+            Optional destination directory for the archive (including storage
+            prefix). When omitted, the backend falls back to `path`.
+          example: "local://documents/backups"
 
     UnarchiveRequest:
       type: object
@@ -287,7 +287,14 @@ components:
           example: "local://documents/archive.zip"
         path:
           type: string
-          description: Directory path where archive contents should be extracted (including storage prefix)
+          description: Current directory path (including storage prefix)
+          example: "local://documents"
+        destination:
+          type: string
+          description: >-
+            Optional destination directory where the archive contents should be
+            extracted (including storage prefix). When omitted, the backend
+            extracts into `path`.
           example: "local://documents/extracted"
 
     CreateItemRequest:
@@ -420,6 +427,17 @@ paths:
                   type: string
                   description: Target directory path (including storage prefix)
                   example: "local://uploads"
+                name:
+                  type: string
+                  description: >-
+                    Optional file name sent alongside the upload. Defaults to
+                    the uploaded file's original name; may include a relative
+                    sub-path when uploading a folder.
+                  example: "report.pdf"
+                type:
+                  type: string
+                  description: Optional MIME type of the uploaded file.
+                  example: "application/pdf"
       responses:
         '200':
           description: Files uploaded successfully. Returns empty JSON response.

--- a/docs/api-reference/types.md
+++ b/docs/api-reference/types.md
@@ -214,6 +214,7 @@ export interface VueFinderComposable {
   preview(path: string): void;
   notify(type: 'success' | 'error' | 'info' | 'warning', message: string): void;
   getPath(): string;
+  path: Readonly<Ref<string>>;
   select(paths: string[]): void;
   selectOne(path: string): void;
   clearSelection(): void;
@@ -234,6 +235,7 @@ export interface VueFinderComposable {
 **Behavior notes:**
 
 - `useVueFinder(id)` throws if the target instance is not mounted.
+- `path` is a reactive ref of the current directory — `watch()` it or bind it in a template instead of polling `getPath()` or listening for `@path-change`.
 - `select(paths)` only selects items that exist in the current loaded directory.
 - Mutating methods delegate to the driver and sync the in-memory file list from returned `files`.
 

--- a/docs/guide/composable-api.md
+++ b/docs/guide/composable-api.md
@@ -55,7 +55,8 @@ const testNotify = () => {
 | --- | --- | --- |
 | `refresh` | `() => Promise<void>` | Reload the current directory |
 | `open` | `(path: string) => Promise<void>` | Navigate to a path |
-| `getPath` | `() => string` | Current directory path |
+| `getPath` | `() => string` | Current directory path (one-off snapshot) |
+| `path` | `Readonly<Ref<string>>` | Reactive current directory path — `watch()` it or bind it directly, no `@path-change` wiring needed |
 | `getFiles` | `() => DirEntry[]` | Entries in the current directory |
 | `getStorages` | `() => string[]` | Available storage names |
 | `isLoading` | `() => boolean` | Whether a request is in flight |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vuefinder",
-  "version": "4.5.5",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuefinder",
-      "version": "4.5.5",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefinder",
-  "version": "4.5.5",
+  "version": "4.6.0",
   "description": "A sleek, developer-friendly file manager for Vue — organize, preview, and manage files with ease.",
   "type": "module",
   "engines": {

--- a/src/__tests__/Vuefinder.spec.ts
+++ b/src/__tests__/Vuefinder.spec.ts
@@ -378,7 +378,7 @@ describe('VueFinder', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const testFile = files[0];
-      app.fs.select(testFile.path);
+      app.fs.select(`${testFile.type}:${testFile.path}`);
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // onSelect should be called

--- a/src/__tests__/useVueFinder.spec.ts
+++ b/src/__tests__/useVueFinder.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { atom } from 'nanostores';
 import { useVueFinder } from '../composables/useVueFinder';
 import { registerApp, unregisterApp } from '../composables/useApp';
 import type { App, DirEntry } from '../types';
@@ -28,7 +29,7 @@ function createMockApp() {
   const selectionSet = new Set<string>();
 
   const fs = {
-    path: { get: vi.fn(() => ({ path: 'local://docs' })) },
+    path: atom({ storage: 'local', breadcrumb: [], path: 'local://docs' }),
     files: { get: vi.fn(() => files) },
     storages: { get: vi.fn(() => ['local']) },
     selectedItems: { get: vi.fn(() => selectedItems) },
@@ -123,6 +124,17 @@ describe('useVueFinder', () => {
     expect(app.adapter.copy).toHaveBeenCalled();
     expect(app.adapter.move).toHaveBeenCalled();
     expect(app.fs.setFiles).toHaveBeenCalled();
+  });
+
+  it('exposes a reactive path ref that tracks navigation', () => {
+    const app = createMockApp();
+    registerApp(id, app);
+    const finder = useVueFinder(id);
+
+    expect(finder.path.value).toBe('local://docs');
+
+    app.fs.path.set({ storage: 'local', breadcrumb: [], path: 'local://docs/sub' });
+    expect(finder.path.value).toBe('local://docs/sub');
   });
 
   it('readonly getters return snapshots', () => {

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -12,6 +12,7 @@ import { useApp } from '../composables/useApp';
 import { useItemEvents } from '../composables/useItemEvents';
 import { useScrollSetup } from '../composables/useScrollSetup';
 import { useLazyLoad } from '../composables/useLazyLoad';
+import { entryKey } from '../utils/entryKey';
 import type { DirEntry, ItemDclickEvent } from '../types';
 import type { StoreValue } from 'nanostores';
 import type { ConfigState } from '../stores/config';
@@ -114,7 +115,7 @@ const { explorerId, isDragging, initializeSelectionArea, updateSelectionArea, ha
     totalHeight,
     getItemPosition,
     getItemsInRange,
-    getKey: (f) => f.path,
+    getKey: (f) => entryKey(f),
     selectionObject,
     rowHeight,
     itemWidth,

--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -7,6 +7,7 @@ import type { DirEntry } from '../types';
 import LockSVG from '../assets/icons/lock.svg';
 import { useApp } from '../composables/useApp';
 import { useFeature } from '../composables/useFeature';
+import { entryKey } from '../utils/entryKey';
 
 const props = defineProps<{
   item: DirEntry;
@@ -73,7 +74,7 @@ const itemClasses = computed(() => [
 ]);
 
 const itemStyle = computed(() => ({
-  opacity: props.isDragging || fs.isCut(props.item.path) || !isInteractive.value ? 0.5 : '',
+  opacity: props.isDragging || fs.isCut(entryKey(props.item)) || !isInteractive.value ? 0.5 : '',
 }));
 
 let touchTimeOut: ReturnType<typeof setTimeout> | null = null;
@@ -206,7 +207,7 @@ const delayedOpenItem = (event: TouchEvent) => {
   <div
     :class="itemClasses"
     :style="itemStyle"
-    :data-key="item.path"
+    :data-key="entryKey(item)"
     :data-row="rowIndex"
     :data-col="colIndex"
     :draggable="draggable"

--- a/src/components/FileRow.vue
+++ b/src/components/FileRow.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import FileItem from './FileItem.vue';
 import type { DirEntry } from '../types';
+import { entryKey } from '../utils/entryKey';
 
 const props = defineProps<{
   rowIndex: number;
@@ -56,13 +57,13 @@ const gridStyle = computed(() => {
     <div class="grid justify-self-start" :class="{ 'w-full': view === 'list' }" :style="gridStyle">
       <FileItem
         v-for="(item, colIndex) in items"
-        :key="item.path"
+        :key="entryKey(item)"
         :item="item"
         :view="view"
         :show-thumbnails="showThumbnails"
         :show-path="showPath"
-        :is-selected="isSelected(item.path)"
-        :is-dragging="isDraggingItem(item.path)"
+        :is-selected="isSelected(entryKey(item))"
+        :is-dragging="isDraggingItem(entryKey(item))"
         :row-index="rowIndex"
         :col-index="colIndex"
         :explorer-id="explorerId"

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -4,6 +4,7 @@ import { useStore } from '@nanostores/vue';
 import { useFeature } from '../composables/useFeature';
 import type { DirEntry } from '../types';
 import { copyPath, copyDownloadUrl } from '../utils/clipboard';
+import { entryKey } from '../utils/entryKey';
 import ModalNewFolder from './modals/ModalNewFolder.vue';
 import ModalNewFile from './modals/ModalNewFile.vue';
 import ModalRename from './modals/ModalRename.vue';
@@ -211,7 +212,7 @@ const menuItems = computed<any[]>(() => [
                 if (selectedItems.value.length > 0) {
                   fs?.setClipboard(
                     'cut',
-                    new Set(selectedItems.value.map((item: DirEntry) => item.path))
+                    new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
                   );
                 }
               },
@@ -224,7 +225,7 @@ const menuItems = computed<any[]>(() => [
                 if (selectedItems.value.length > 0) {
                   fs?.setClipboard(
                     'copy',
-                    new Set(selectedItems.value.map((item: DirEntry) => item.path))
+                    new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
                   );
                 }
               },

--- a/src/composables/useDragNDrop.ts
+++ b/src/composables/useDragNDrop.ts
@@ -2,6 +2,7 @@ import ModalMove from '../components/modals/ModalMove.vue';
 import type { App, DirEntry, DirEntryType } from '../types';
 import { useStore } from '@nanostores/vue';
 import type { StoreValue } from 'nanostores';
+import { entryKey } from '../utils/entryKey';
 
 export interface DragNDropItem {
   path: string;
@@ -75,7 +76,11 @@ export function useDragNDrop(app: App, classList: string[] = []) {
 
     e.preventDefault();
 
-    const draggedPath = fs.getDraggedItem() as string;
+    // getDraggedItem() holds the composite entry key; resolve it back to the
+    // dragged entry's path for the descendant / self-drop checks.
+    const draggedKey = fs.getDraggedItem() as string;
+    const draggedPath =
+      fs.sortedFiles.get().find((f: DirEntry) => entryKey(f) === draggedKey)?.path ?? '';
 
     if (isInvalidDropTarget(target, draggedPath)) {
       if (e.dataTransfer) {
@@ -152,9 +157,9 @@ export function useDragNDrop(app: App, classList: string[] = []) {
     el.classList.remove(...classList);
     const data = e.dataTransfer?.getData('items') || '[]';
     const draggedItemKeys: string[] = JSON.parse(data);
-    const draggedItems: DirEntry[] = draggedItemKeys.map(
-      (key) => fs.sortedFiles.get().find((f: DirEntry) => f.path === key) as DirEntry
-    );
+    const draggedItems: DirEntry[] = draggedItemKeys
+      .map((key) => fs.sortedFiles.get().find((f: DirEntry) => entryKey(f) === key))
+      .filter((f): f is DirEntry => Boolean(f));
     fs.clearDraggedItem();
     app.modal.open(ModalMove, { items: { from: draggedItems, to: target } });
   }

--- a/src/composables/useHotkeyActions.ts
+++ b/src/composables/useHotkeyActions.ts
@@ -14,6 +14,7 @@ import type { CurrentPathState } from '@/stores/files';
 import { useApp } from './useApp';
 import { useFeature } from './useFeature';
 import { createNotifier } from '../utils/notify';
+import { entryKey } from '../utils/entryKey';
 
 const KEYBOARD_SHORTCUTS = {
   ESCAPE: 'Escape',
@@ -101,7 +102,7 @@ export function useHotkeyActions() {
         notify.error(app.i18n.t('No items selected'));
         return;
       }
-      fs.setClipboard('copy', new Set(selectedItems.value.map((item: any) => item.path)));
+      fs.setClipboard('copy', new Set(selectedItems.value.map((item: DirEntry) => entryKey(item))));
       notify.success(
         selectedItems.value.length === 1
           ? app.i18n.t('Item copied to clipboard')
@@ -115,7 +116,7 @@ export function useHotkeyActions() {
         notify.error(app.i18n.t('No items selected'));
         return;
       }
-      fs.setClipboard('cut', new Set(selectedItems.value.map((item: any) => item.path)));
+      fs.setClipboard('cut', new Set(selectedItems.value.map((item: DirEntry) => entryKey(item))));
       notify.success(
         selectedItems.value.length === 1
           ? app.i18n.t('Item cut to clipboard')

--- a/src/composables/useItemEvents.ts
+++ b/src/composables/useItemEvents.ts
@@ -4,6 +4,7 @@ import type { DirEntry, App } from '../types';
 import type SelectionAraa from '@viselect/vanilla';
 import { useItemFilters } from './useItemFilters';
 import { useItemOperations } from './useItemOperations';
+import { entryKey } from '../utils/entryKey';
 
 /**
  * Composable for handling item events (click, double-click, context menu)
@@ -31,7 +32,7 @@ export function useItemEvents(
     if (!el) return null;
 
     const key = String(el.getAttribute('data-key'));
-    const item = sortedFiles.value?.find((f: DirEntry) => f.path === key);
+    const item = sortedFiles.value?.find((f: DirEntry) => entryKey(f) === key);
     return { key, item };
   };
 
@@ -40,7 +41,7 @@ export function useItemEvents(
    */
   const getSelectedItems = (): DirEntry[] => {
     const selected = selectedKeys.value;
-    return sortedFiles.value?.filter((f: DirEntry) => selected?.has(f.path)) || [];
+    return sortedFiles.value?.filter((f: DirEntry) => selected?.has(entryKey(f))) || [];
   };
 
   /**

--- a/src/composables/useVueFinder.ts
+++ b/src/composables/useVueFinder.ts
@@ -1,10 +1,19 @@
+import { computed } from 'vue';
+import { useStore } from '@nanostores/vue';
+import type { StoreValue } from 'nanostores';
 import { useApp } from './useApp';
+import type { CurrentPathState } from '../stores/files';
 import type { DirEntry, VueFinderComposable } from '../types';
 import ModalPreview from '../components/modals/ModalPreview.vue';
 import { notify as emitNotify } from '../utils/notify';
 
 export function useVueFinder(id: string): VueFinderComposable {
   const app = useApp(id);
+
+  // Reactive mirror of the current path so consumers can `watch()` it or bind
+  // it in a template without wiring up the `@path-change` event (issue #186).
+  const pathState: StoreValue<CurrentPathState> = useStore(app.fs.path);
+  const path = computed<string>(() => pathState.value?.path ?? '');
 
   const resolvePath = (path?: string): string => {
     return path || app.fs.path.get().path || '';
@@ -40,6 +49,8 @@ export function useVueFinder(id: string): VueFinderComposable {
     getPath() {
       return app.fs.path.get().path || '';
     },
+
+    path,
 
     select(paths: string[]) {
       const available = new Set((app.fs.files.get() || []).map((item: DirEntry) => item.path));

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -1,6 +1,7 @@
 import { atom, computed, type StoreValue } from 'nanostores';
 import type { DirEntry } from '../types';
 import { useStore } from '@nanostores/vue';
+import { entryKey } from '../utils/entryKey';
 
 export type SortColumn = 'basename' | 'file_size' | 'last_modified' | 'path' | '';
 export type SortOrder = 'asc' | 'desc' | '';
@@ -101,7 +102,7 @@ export const createFilesStore = () => {
   // Selection helpers
   const selectedItems = computed([files, selectedKeys], (filesValue, selectedKeysValue) => {
     if (selectedKeysValue.size === 0) return [];
-    return filesValue.filter((f) => selectedKeysValue.has(f.path));
+    return filesValue.filter((f) => selectedKeysValue.has(entryKey(f)));
   });
 
   // Actions
@@ -228,7 +229,7 @@ export const createFilesStore = () => {
     if (selectionMode === 'single') {
       const firstFile = files.get()[0];
       if (firstFile) {
-        const firstKey = firstFile.path;
+        const firstKey = entryKey(firstFile);
         selectedKeys.set(new Set([firstKey]));
         selectedCount.set(1);
       }
@@ -262,12 +263,12 @@ export const createFilesStore = () => {
 
             return true;
           })
-          .map((f) => f.path);
+          .map((f) => entryKey(f));
 
         selectedKeys.set(new Set(selectableKeys));
       } else {
         // No filters, select all
-        const allKeys = new Set(files.get().map((f) => f.path));
+        const allKeys = new Set(files.get().map((f) => entryKey(f)));
         selectedKeys.set(allKeys);
       }
       setSelectedCount(selectedKeys.get().size);
@@ -279,8 +280,17 @@ export const createFilesStore = () => {
     selectedCount.set(0);
   };
 
-  const setSelection = (keys: string[]) => {
-    const newKeys = new Set(keys ?? []);
+  const setSelection = (paths: string[]) => {
+    // Public callers select by path; resolve each to the matching entries'
+    // composite keys so selection works even when a file and folder share a
+    // path. An ambiguous path selects every entry that carries it.
+    const wanted = new Set(paths ?? []);
+    const newKeys = new Set(
+      files
+        .get()
+        .filter((f) => wanted.has(f.path))
+        .map((f) => entryKey(f))
+    );
     selectedKeys.set(newKeys);
     selectedCount.set(newKeys.size);
   };
@@ -298,7 +308,7 @@ export const createFilesStore = () => {
   };
 
   const setClipboard = (type: 'cut' | 'copy', items: Set<string>) => {
-    const copiedItems = files.get().filter((f) => items.has(f.path));
+    const copiedItems = files.get().filter((f) => items.has(entryKey(f)));
     clipboardItems.set({
       type,
       path: path.get().path,
@@ -309,13 +319,17 @@ export const createFilesStore = () => {
   // Reactive versions that return computed atoms
   const createIsCut = (key: string) => {
     return computed([clipboardItems], (clipboard) => {
-      return clipboard.type === 'cut' && Array.from(clipboard.items).some((f) => f.path === key);
+      return (
+        clipboard.type === 'cut' && Array.from(clipboard.items).some((f) => entryKey(f) === key)
+      );
     });
   };
 
   const createIsCopied = (key: string) => {
     return computed([clipboardItems], (clipboard) => {
-      return clipboard.type === 'copy' && Array.from(clipboard.items).some((f) => f.path === key);
+      return (
+        clipboard.type === 'copy' && Array.from(clipboard.items).some((f) => entryKey(f) === key)
+      );
     });
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue';
 import type { Item as ContextMenuItem } from './utils/contextmenu';
 import ServiceContainer from './ServiceContainer';
 import type { Driver } from './adapters';
@@ -63,6 +64,8 @@ export interface VueFinderComposable {
   preview: (path: string) => void;
   notify: (type: 'success' | 'error' | 'info' | 'warning', message: string) => void;
   getPath: () => string;
+  /** Reactive current directory path. Updates as the user navigates. */
+  path: Readonly<Ref<string>>;
   select: (paths: string[]) => void;
   selectOne: (path: string) => void;
   clearSelection: () => void;

--- a/src/utils/contextmenu.ts
+++ b/src/utils/contextmenu.ts
@@ -7,6 +7,7 @@ import ModalDelete from '../components/modals/ModalDelete.vue';
 import ModalMove from '../components/modals/ModalMove.vue';
 import ModalCopy from '../components/modals/ModalCopy.vue';
 import type { App, DirEntry } from '../types';
+import { entryKey } from './entryKey';
 
 type TargetKey = 'none' | 'one' | 'many';
 
@@ -287,7 +288,7 @@ export const menuItems: Item[] = [
     title: ({ t }) => t('Copy'),
     action: (app, selectedItems) => {
       if (selectedItems.length > 0) {
-        app.fs.setClipboard('copy', new Set(selectedItems.map((item: DirEntry) => item.path)));
+        app.fs.setClipboard('copy', new Set(selectedItems.map((item: DirEntry) => entryKey(item))));
       }
     },
     show: showIfAny(

--- a/src/utils/entryKey.ts
+++ b/src/utils/entryKey.ts
@@ -1,0 +1,17 @@
+import type { DirEntry, DirEntryType } from '../types';
+
+/**
+ * Unique identity for a directory entry used as the selection / clipboard /
+ * drag key throughout the explorer.
+ *
+ * `path` alone is NOT unique: storage backends with virtual directories
+ * (e.g. S3/R2) can expose a file and a folder that share the same path, so
+ * keying on the bare path makes both entries collide — selecting one selects
+ * both, and double-clicking the file navigates into the folder (issue #185).
+ *
+ * Combining the type with the path disambiguates them. The result is an opaque
+ * key: it is only ever compared against other `entryKey()` values, never parsed
+ * back into a path.
+ */
+export const entryKey = (entry: { type: DirEntryType; path: string } | DirEntry): string =>
+  `${entry.type}:${entry.path}`;


### PR DESCRIPTION
## Summary
Batch of three issue fixes, ready for 4.6.0.

### fix: same-named file & folder selection (#185)
Selection, clipboard and drag identity all keyed on the bare entry path, so on storage backends with virtual directories (S3/R2/GCS) a file and a folder sharing a name collided — selecting one selected both, and double-clicking the file navigated into the folder. Introduces a composite `entryKey` (`type:path`) used wherever an entry's identity is derived; the public path-based select API is unchanged.

### feat: reactive `path` ref on `useVueFinder` (#186)
`getPath()` returns a non-reactive snapshot. Adds a reactive `path` (`Readonly<Ref<string>>`) that tracks navigation, so consumers can `watch()` it or bind it directly without wiring up `@path-change`.

### docs: OpenAPI spec alignment (#184)
- `/upload`: document optional `name` and `type` multipart fields
- shared `ItemReference` schema reused by `DeleteRequest` and `ArchiveRequest`
- `archive`/`unarchive`: document the optional `destination` field VueFinder sends

## Verification
- `vitest`: 20 passing
- `vue-tsc`, ESLint, Prettier: clean

Closes #184, #185, #186