### PR TITLE
fix: set caret-color to currentColor so cursor is visible in dark mode

### DIFF
--- a/src/assets/css/_previews.css
+++ b/src/assets/css/_previews.css
@@ -244,6 +244,12 @@
     'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
 }
 
+/* The browser default caret color is black, which is invisible on dark backgrounds.
+   Inherit the text color so the cursor remains visible in any theme. */
+.vuefinder__codemirror-editor .cm-content {
+  caret-color: currentColor;
+}
+
 /* iOS Safari auto-zooms when a contenteditable has font-size < 16px.
    Keep the editor readable at the desktop size but bump mobile to 16px. */
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- In dark mode, the CodeMirror text cursor is invisible because the browser default `caret-color` is black, which blends into dark backgrounds.
- Setting `caret-color: currentColor` on `.cm-content` inherits the editor's text color, keeping the cursor visible in any theme.

## Fix

```css
.vuefinder__codemirror-editor .cm-content {
  caret-color: currentColor;
}
```

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)