### PR TITLE
Feature: add slot options for menu, toolbar and breadrumb. 

### DIFF
--- a/docs/api-reference/slots.md
+++ b/docs/api-reference/slots.md
@@ -16,7 +16,7 @@ Complete reference of all VueFinder slots.
 | `menu-items`     | `{ menuItems, handleMenuAction }`        | Replace the default File/Edit/View/Go/Help menu bar layout     |
 | `menubar-end`    | `{ menuItems }`                          | Add content after the default menu bar entries                 |
 | `toolbar-items`  | none                                     | Replace the entire toolbar                                     |
-| `breadcrumb-items` | none                                   | Replace the entire breadcrumb bar                               |
+| `breadcrumb-actions` | none                                 | Replace the action buttons before the breadcrumb path (tree-view toggle, go up, refresh) |
 
 ## Slot Details
 
@@ -88,21 +88,27 @@ toggles, ...).
 </template>
 ```
 
-### `breadcrumb-items`
+### `breadcrumb-actions`
 
-Replace the entire breadcrumb bar. No scoped props are passed; a custom
-component should call `useBreadcrumbActions()` to reuse the built-in
-navigation actions (refresh, go up, toggle tree view, copy path) and reactive
-`currentPath`.
+Replace the action buttons shown before the breadcrumb path (tree-view
+toggle, go up, refresh/cancel). No scoped props are passed; a custom
+component should call `useBreadcrumbActions()` to reuse the built-in actions
+(refresh, go up, toggle tree view) and reactive `currentPath`.
+
+The path container itself (breadcrumb trail with overflow measurement, drag
+& drop, the hidden-item dropdown, and path-copy mode) is **not** slotted -
+it's complex enough that reimplementing it wouldn't make sense, so it always
+renders as-is.
 
 ```vue
-<template #breadcrumb-items>
-  <MyCustomBreadcrumb />
+<template #breadcrumb-actions>
+  <MyCustomBreadcrumbActions />
 </template>
 ```
 
-Combine `toolbar-items`, `breadcrumb-items` and `menu-items` (with
-`showToolbar`/`showBreadcrumbBar` set to `false`) to merge everything into a
-single custom bar - see the "MenuBar Customization" example.
+Combine `toolbar-items`, `breadcrumb-actions` and `menu-items` to merge menu,
+toolbar and breadcrumb-action functionality into a single custom bar (set
+`showToolbar: false` and, if you don't need the path trail at all,
+`showBreadcrumbBar: false`) - see the "MenuBar Customization" example.
 
 For usage examples and common patterns, see [Guide - Slots](../guide/slots.md).

--- a/docs/api-reference/slots.md
+++ b/docs/api-reference/slots.md
@@ -8,10 +8,15 @@ Complete reference of all VueFinder slots.
 
 ## Available Slots
 
-| Slot         | Scoped Props                | Description                  |
-| ------------ | --------------------------- | ---------------------------- |
-| `status-bar` | `{ selected, count, path }` | Customize status bar content |
-| `icon`       | `{ item }`                  | Customize file/folder icons  |
+| Slot             | Scoped Props                            | Description                                                |
+| ---------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| `status-bar`     | `{ selected, count, path }`              | Customize status bar content                                |
+| `icon`           | `{ item }`                               | Customize file/folder icons                                  |
+| `menubar-start`  | `{ menuItems }`                          | Add content before the default menu bar entries               |
+| `menu-items`     | `{ menuItems, handleMenuAction }`        | Replace the default File/Edit/View/Go/Help menu bar layout     |
+| `menubar-end`    | `{ menuItems }`                          | Add content after the default menu bar entries                 |
+| `toolbar-items`  | none                                     | Replace the entire toolbar                                     |
+| `breadcrumb-items` | none                                   | Replace the entire breadcrumb bar                               |
 
 ## Slot Details
 
@@ -47,5 +52,57 @@ Customize the icon displayed for files and folders.
   <CustomIcon :item="item" />
 </template>
 ```
+
+### `menubar-start` / `menu-items` / `menubar-end`
+
+Customize the menu bar. `menu-items` replaces the default File/Edit/View/Go/Help
+layout entirely (fallback is the default rendering); `menubar-start`/`menubar-end`
+add content before/after it without touching the default menus.
+
+**Scoped Props:**
+
+- `menuItems` - `MenuItem[]` - The same menu structure `MenuBar.vue` renders by default (also available standalone via the `useMenuItems()` composable)
+- `handleMenuAction` - `(action?: () => void) => void` - Closes the open dropdown, then runs the action (only passed to `menu-items`)
+
+```vue
+<template #menu-items="{ menuItems, handleMenuAction }">
+  <MyCustomMenuBar :menu-items="menuItems" @action="handleMenuAction" />
+</template>
+```
+
+A custom component placed in any of these slots can also skip the scoped props
+entirely and call `useMenuItems()` / `useBreadcrumbActions()` directly - both
+resolve against the surrounding VueFinder instance, reusing the exact same
+actions (including modal-opening behavior) as the built-in components.
+
+### `toolbar-items`
+
+Replace the entire toolbar. No scoped props are passed; a custom component
+should call `useMenuItems()`/`useFeature()`/`useApp()` itself to reuse the
+built-in file actions (new folder, upload, rename, delete, archive, view
+toggles, ...).
+
+```vue
+<template #toolbar-items>
+  <MyCustomToolbar />
+</template>
+```
+
+### `breadcrumb-items`
+
+Replace the entire breadcrumb bar. No scoped props are passed; a custom
+component should call `useBreadcrumbActions()` to reuse the built-in
+navigation actions (refresh, go up, toggle tree view, copy path) and reactive
+`currentPath`.
+
+```vue
+<template #breadcrumb-items>
+  <MyCustomBreadcrumb />
+</template>
+```
+
+Combine `toolbar-items`, `breadcrumb-items` and `menu-items` (with
+`showToolbar`/`showBreadcrumbBar` set to `false`) to merge everything into a
+single custom bar - see the "MenuBar Customization" example.
 
 For usage examples and common patterns, see [Guide - Slots](../guide/slots.md).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -38,6 +38,7 @@ All configuration options are passed via the `config` prop:
 | `persist`                   | `boolean`                                                                                               | `false`           | Persist current path/config to localStorage                                 |
 | `showMenuBar`               | `boolean`                                                                                               | `true`            | Show menu bar (non-persistent, resets on page reload)                      |
 | `showToolbar`               | `boolean`                                                                                               | `true`            | Show toolbar (non-persistent, resets on page reload)                       |
+| `showBreadcrumbBar`            | `boolean`                                                                                               | `true`            | Show breadcrumb bar (non-persistent, resets on page reload)                 |
 | `initialPath`               | `string \| null`                                                                                        | `null`            | Initial path on mount                                                       |
 | `loadingIndicator`          | `'linear' \| 'circular' \| string`                                                                      | `'circular'`      | Loading indicator style                                                     |
 | `maxFileSize`               | `number \| string \| null`                                                                              | `null`            | Maximum file upload size (e.g., `'10mb'`, `'50mb'`)                        |
@@ -128,7 +129,9 @@ The persisted values live under the `vuefinder_config_<id>` localStorage key. To
 
 ### UI Visibility Settings
 
-You can control the visibility of the menu bar and toolbar using the `showMenuBar` and `showToolbar` config options. These are non-persistent options that reset to their default values (`true`) on page reload.
+You can control the visibility of the menu bar, toolbar and breadcrumb bar using the `showMenuBar`, `showToolbar` and `showBreadcrumbBar` config options. These are non-persistent options that reset to their default values (`true`) on page reload.
+
+Setting `showBreadcrumbBar: false` is useful when a custom menu bar (built via `MenuBar`'s `#menu-items` slot) already displays the current path and navigation actions, so the default breadcrumb bar would be redundant.
 
 For detailed examples and usage, see the [UI Visibility example](/examples/ui-visibility).
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -108,4 +108,98 @@ import PDFIcon from './PDFIcon.vue';
 
 If the condition doesn't match, the default icon will be shown automatically.
 
+### MenuBar Slots: `menubar-start`, `menu-items`, `menubar-end`
+
+Add content around the default menu bar, or replace it entirely.
+
+**Scoped Props (all three):**
+
+- `menuItems` - `MenuItem[]` - the default File/Edit/View/Go/Help structure
+- `handleMenuAction` - only passed to `menu-items` - closes the open dropdown, then runs the action
+
+#### Example: Add a button after the default menus
+
+```vue
+<template>
+  <vue-finder id="menubar-extra" :driver="driver">
+    <template #menubar-end="{ menuItems }">
+      <div class="menubar-chip">{{ menuItems.length }} menus</div>
+    </template>
+  </vue-finder>
+</template>
+```
+
+#### Example: Fully replace the menu bar layout
+
+A custom component doesn't have to rely on the scoped props - it can call
+`useMenuItems()` directly to get the exact same data (and modal-opening
+actions) `MenuBar.vue` uses internally:
+
+```vue
+<!-- MyMenuBar.vue -->
+<script setup>
+import { useMenuItems } from 'vuefinder';
+
+const { menuItems } = useMenuItems();
+</script>
+
+<template>
+  <div class="my-menu-bar">
+    <button v-for="menu in menuItems" :key="menu.id">{{ menu.label }}</button>
+  </div>
+</template>
+```
+
+```vue
+<template #menu-items>
+  <MyMenuBar />
+</template>
+```
+
+### `toolbar-items` Slot
+
+Replace the entire toolbar. No scoped props are passed - a custom component
+calls `useMenuItems()`/`useFeature()`/`useApp()` itself to reuse the built-in
+actions (new folder, upload, rename, delete, archive, view toggles, ...).
+
+```vue
+<template #toolbar-items>
+  <MyCustomToolbar />
+</template>
+```
+
+### `breadcrumb-items` Slot
+
+Replace the entire breadcrumb bar. No scoped props are passed - a custom
+component calls `useBreadcrumbActions()` to reuse the built-in navigation
+actions (refresh, go up, toggle tree view, copy path) and the reactive
+`currentPath`.
+
+```vue
+<!-- MyBreadcrumb.vue -->
+<script setup>
+import { useBreadcrumbActions } from 'vuefinder';
+
+const breadcrumb = useBreadcrumbActions();
+</script>
+
+<template>
+  <div class="my-breadcrumb">
+    <span>{{ breadcrumb.currentPath.path }}</span>
+    <button @click="breadcrumb.refresh()">Refresh</button>
+    <button @click="breadcrumb.goUp()">Go Up</button>
+  </div>
+</template>
+```
+
+```vue
+<template #breadcrumb-items>
+  <MyBreadcrumb />
+</template>
+```
+
+To merge everything into a single custom bar, combine `menu-items` with
+`showToolbar: false` and `showBreadcrumbBar: false` in the `config` prop - see
+the "MenuBar Customization" example for a full walkthrough.
+
 For complete slot reference, see [API Reference - Slots](../api-reference/slots.md).

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -168,15 +168,20 @@ actions (new folder, upload, rename, delete, archive, view toggles, ...).
 </template>
 ```
 
-### `breadcrumb-items` Slot
+### `breadcrumb-actions` Slot
 
-Replace the entire breadcrumb bar. No scoped props are passed - a custom
-component calls `useBreadcrumbActions()` to reuse the built-in navigation
-actions (refresh, go up, toggle tree view, copy path) and the reactive
-`currentPath`.
+Replace the action buttons shown before the breadcrumb path - tree-view
+toggle, go up, refresh/cancel. No scoped props are passed - a custom
+component calls `useBreadcrumbActions()` to reuse the built-in actions
+(refresh, go up, toggle tree view) and the reactive `currentPath`.
+
+The path container itself (the breadcrumb trail, with overflow measurement,
+drag & drop, the hidden-item dropdown, and path-copy mode) is intentionally
+**not** slotted - it's complex enough that reimplementing it wouldn't make
+sense, so it always renders as-is, right after this slot.
 
 ```vue
-<!-- MyBreadcrumb.vue -->
+<!-- MyBreadcrumbActions.vue -->
 <script setup>
 import { useBreadcrumbActions } from 'vuefinder';
 
@@ -184,22 +189,24 @@ const breadcrumb = useBreadcrumbActions();
 </script>
 
 <template>
-  <div class="my-breadcrumb">
-    <span>{{ breadcrumb.currentPath.path }}</span>
-    <button @click="breadcrumb.refresh()">Refresh</button>
+  <div class="my-breadcrumb-actions">
+    <button @click="breadcrumb.toggleTreeView()">Tree</button>
     <button @click="breadcrumb.goUp()">Go Up</button>
+    <button @click="breadcrumb.refresh()">Refresh</button>
   </div>
 </template>
 ```
 
 ```vue
-<template #breadcrumb-items>
-  <MyBreadcrumb />
+<template #breadcrumb-actions>
+  <MyBreadcrumbActions />
 </template>
 ```
 
-To merge everything into a single custom bar, combine `menu-items` with
-`showToolbar: false` and `showBreadcrumbBar: false` in the `config` prop - see
-the "MenuBar Customization" example for a full walkthrough.
+To merge menu bar, toolbar and breadcrumb actions into a single custom bar,
+combine `menu-items` with `showToolbar: false` in the `config` prop (add
+`showBreadcrumbBar: false` too if you don't need the default path trail
+alongside it) - see the "MenuBar Customization" example for a full
+walkthrough.
 
 For complete slot reference, see [API Reference - Slots](../api-reference/slots.md).

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -18,6 +18,7 @@ import SingleSelectionExample from './examples/SingleSelectionExample.vue';
 import SelectionFilterExample from './examples/SelectionFilterExample.vue';
 import FeaturesExample from './examples/FeaturesExample.vue';
 import UIVisibilityExample from './examples/UIVisibilityExample.vue';
+import MenuBarCustomizationExample from './examples/MenuBarCustomizationExample.vue';
 import ItemSizeExample from './examples/ItemSizeExample.vue';
 import MultilangExample from './examples/MultilangExample.vue';
 import ComposableApiExample from './examples/ComposableApiExample.vue';
@@ -135,6 +136,7 @@ const examples = {
   selectionFilter: 'Selection Filter Demo',
   features: 'Features Configuration Demo',
   uiVisibility: 'UI Visibility Settings Demo',
+  menuBarCustomization: 'MenuBar Customization (Slots Demo)',
   itemSize: 'Item Size & Spacing Configuration',
   multilang: 'Multilang File Manager Demo',
 };
@@ -430,6 +432,13 @@ onUnmounted(() => {
 
       <UIVisibilityExample
         v-if="example === 'uiVisibility'"
+        :driver="driver"
+        :config="{ ...config, theme: currentTheme }"
+        :features="features"
+      />
+
+      <MenuBarCustomizationExample
+        v-if="example === 'menuBarCustomization'"
         :driver="driver"
         :config="{ ...config, theme: currentTheme }"
         :features="features"

--- a/examples/examples/MenuBarCombinedBar.vue
+++ b/examples/examples/MenuBarCombinedBar.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+// Demonstrates reusing the exact same actions that power the default
+// MenuBar/Breadcrumb (including their modal-opening behavior) to build a
+// single custom bar. This component is rendered through MenuBar's
+// `#menu-items` slot, so `useMenuItems()`/`useBreadcrumbActions()` resolve
+// against the surrounding VueFinder instance just like they do inside the
+// library's own components.
+import { useMenuItems, useBreadcrumbActions } from '../../src';
+import type { MenuItem } from '../../src';
+
+const { menuItems } = useMenuItems();
+const breadcrumb = useBreadcrumbActions();
+
+function flatActionable(menu: MenuItem | undefined): MenuItem[] {
+  if (!menu?.items) return [];
+  return menu.items.filter(
+    (item) => item.type !== 'separator' && !item.items?.length && !item.hidden?.()
+  );
+}
+
+const fileActions = () => flatActionable(menuItems.value.find((m) => m.id === 'file'));
+const editActions = () => flatActionable(menuItems.value.find((m) => m.id === 'edit'));
+// Grid/List view + Fullscreen toggles - the same actions the default Toolbar
+// exposes, so hiding the Toolbar (`showToolbar: false`) doesn't lose them.
+const viewActions = () =>
+  flatActionable(menuItems.value.find((m) => m.id === 'view')).filter((item) =>
+    ['grid-view', 'list-view', 'fullscreen'].includes(item.id ?? '')
+  );
+
+function run(item: MenuItem) {
+  if (item.enabled && !item.enabled()) return;
+  item.action?.();
+}
+</script>
+
+<template>
+  <div class="combined-bar">
+    <div class="combined-bar__group combined-bar__group--path">
+      <span class="combined-bar__path">{{ breadcrumb.currentPath.path }}</span>
+    </div>
+
+    <div class="combined-bar__group">
+      <span class="combined-bar__group-label">File</span>
+      <button
+        v-for="item in fileActions()"
+        :key="item.id"
+        class="combined-bar__btn"
+        :disabled="item.enabled ? !item.enabled() : false"
+        @click="run(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <div class="combined-bar__group">
+      <span class="combined-bar__group-label">Edit</span>
+      <button
+        v-for="item in editActions()"
+        :key="item.id"
+        class="combined-bar__btn"
+        :disabled="item.enabled ? !item.enabled() : false"
+        @click="run(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <div class="combined-bar__group">
+      <span class="combined-bar__group-label">View</span>
+      <button
+        v-for="item in viewActions()"
+        :key="item.id"
+        class="combined-bar__btn"
+        :class="{ 'combined-bar__btn--checked': item.checked?.() }"
+        :disabled="item.enabled ? !item.enabled() : false"
+        @click="run(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <div class="combined-bar__group">
+      <span class="combined-bar__group-label">Breadcrumb actions</span>
+      <button class="combined-bar__btn" @click="breadcrumb.refresh()">Refresh</button>
+      <button class="combined-bar__btn" @click="breadcrumb.goUp()">Go Up</button>
+      <button class="combined-bar__btn" @click="breadcrumb.toggleTreeView()">Toggle Tree</button>
+      <button class="combined-bar__btn" @click="breadcrumb.copyCurrentPath()">Copy Path</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.combined-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  padding: 6px 10px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.combined-bar__group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.combined-bar__group--path {
+  flex-basis: 100%;
+  order: -1;
+  padding-bottom: 4px;
+  margin-bottom: 2px;
+  border-bottom: 1px dashed #e5e7eb;
+}
+
+.combined-bar__path {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Courier New', monospace;
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.combined-bar__group-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 2px;
+}
+
+.combined-bar__btn {
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.combined-bar__btn:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
+.combined-bar__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.combined-bar__btn--checked {
+  background: #e0e7ff;
+  border-color: #6366f1;
+}
+</style>

--- a/examples/examples/MenuBarCustomizationExample.vue
+++ b/examples/examples/MenuBarCustomizationExample.vue
@@ -114,12 +114,17 @@ const computedConfig = computed(() => ({
         </template>
       </vue-finder>
 
-      <!-- Mode 4: MenuBar, Toolbar and Breadcrumb are each replaced
-           independently via their own slot (`menu-items`, `toolbar-items`,
-           `breadcrumb-items`) - three separate custom components, three
-           separate slots, all still shown (showMenuBar/showToolbar/
-           showBreadcrumbBar stay true; the slot content replaces what's
-           *inside* each bar, it doesn't hide the bar itself). -->
+      <!-- Mode 4: MenuBar, Toolbar and the Breadcrumb's action buttons are
+           each replaced independently via their own slot (`menu-items`,
+           `toolbar-items`, `breadcrumb-actions`) - three separate custom
+           components, three separate slots, all still shown
+           (showMenuBar/showToolbar/showBreadcrumbBar stay true; the slot
+           content replaces what's *inside* each bar, it doesn't hide the
+           bar itself). Note: `breadcrumb-actions` only covers the buttons
+           shown before the path (tree-view toggle, go up, refresh) - the
+           path container itself (overflow measurement, drag & drop, hidden-
+           item dropdown, path-copy mode) is intentionally not slotted, since
+           reimplementing it wouldn't make sense. -->
       <vue-finder
         v-else
         id="menubar_custom_all_slots"
@@ -133,8 +138,8 @@ const computedConfig = computed(() => ({
         <template #toolbar-items>
           <div class="all-slots-chip">Custom Toolbar</div>
         </template>
-        <template #breadcrumb-items>
-          <div class="all-slots-chip">Custom Breadcrumb</div>
+        <template #breadcrumb-actions>
+          <div class="all-slots-chip">Custom Breadcrumb Actions</div>
         </template>
       </vue-finder>
     </div>

--- a/examples/examples/MenuBarCustomizationExample.vue
+++ b/examples/examples/MenuBarCustomizationExample.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { Driver } from '../../src/adapters';
+import MenuBarCombinedBar from './MenuBarCombinedBar.vue';
+
+interface Props {
+  driver: Driver;
+  config: Record<string, unknown>;
+  features: unknown;
+}
+
+const props = defineProps<Props>();
+
+type Mode = 'default' | 'start-end' | 'combined' | 'all-slots';
+
+const mode = ref<Mode>('default');
+
+const modes: Record<Mode, string> = {
+  default: 'Default MenuBar (no slots used)',
+  'start-end': 'Add buttons via "menubar-start" / "menubar-end"',
+  combined: 'Replace layout via "menu-items" (reuses useMenuItems + useBreadcrumbActions)',
+  'all-slots': 'Replace MenuBar, Toolbar AND Breadcrumb independently, each via its own slot',
+};
+
+// Independent visibility toggles - same idea as UIVisibilityExample, just
+// extended with `showBreadcrumbBar`. Not tied to `mode`: e.g. uncheck
+// Toolbar/Breadcrumb Bar in "combined" mode to see MenuBarCombinedBar cover
+// the same actions, or uncheck them in "default" mode to see what's lost.
+const showMenuBar = ref(true);
+const showToolbar = ref(true);
+const showBreadcrumbBar = ref(true);
+
+const computedConfig = computed(() => ({
+  ...props.config,
+  showMenuBar: showMenuBar.value,
+  showToolbar: showToolbar.value,
+  showBreadcrumbBar: showBreadcrumbBar.value,
+}));
+</script>
+
+<template>
+  <div class="menubar-customization-example">
+    <div class="menubar-customization-example__controls">
+      <div class="menubar-customization-example__group">
+        <label
+          v-for="(label, key) in modes"
+          :key="key"
+          class="menubar-customization-example__option"
+        >
+          <input v-model="mode" type="radio" :value="key" name="menubar-mode" />
+          {{ label }}
+        </label>
+      </div>
+
+      <div class="menubar-customization-example__group">
+        <label class="menubar-customization-example__option">
+          <input v-model="showMenuBar" type="checkbox" />
+          Show Menu Bar
+        </label>
+        <label class="menubar-customization-example__option">
+          <input v-model="showToolbar" type="checkbox" />
+          Show Toolbar
+        </label>
+        <label class="menubar-customization-example__option">
+          <input v-model="showBreadcrumbBar" type="checkbox" />
+          Show Breadcrumb Bar
+        </label>
+      </div>
+    </div>
+
+    <div class="menubar-customization-example__viewer">
+      <!-- Mode 1: default rendering, no slots passed at all -->
+      <vue-finder
+        v-if="mode === 'default'"
+        id="menubar_custom_default"
+        :driver="driver"
+        :config="computedConfig"
+        :features="features"
+      />
+
+      <!-- Mode 2: keep the default File/Edit/View/Go/Help menus, just add extra
+           entries before/after them (e.g. a branding element or a shortcut button) -->
+      <vue-finder
+        v-else-if="mode === 'start-end'"
+        id="menubar_custom_start_end"
+        :driver="driver"
+        :config="computedConfig"
+        :features="features"
+      >
+        <template #menubar-start>
+          <div class="menubar-chip">🗂️ My App</div>
+        </template>
+        <template #menubar-end="{ menuItems }">
+          <div class="menubar-chip">{{ menuItems.length }} menus</div>
+        </template>
+      </vue-finder>
+
+      <!-- Mode 3: fully replace the menu layout. MenuBarCombinedBar calls
+           useMenuItems()/useBreadcrumbActions() itself, so it isn't limited to
+           what the slot passes in - it mixes in File/Edit/View actions (the
+           same ones the default Toolbar exposes) plus Breadcrumb actions
+           (refresh/go up/toggle tree/copy path) into one custom bar. Uncheck
+           "Show Toolbar" and "Show Breadcrumb Bar" above to see this bar
+           fully cover for both. -->
+      <vue-finder
+        v-else-if="mode === 'combined'"
+        id="menubar_custom_combined"
+        :driver="driver"
+        :config="computedConfig"
+        :features="features"
+      >
+        <template #menu-items>
+          <MenuBarCombinedBar />
+        </template>
+      </vue-finder>
+
+      <!-- Mode 4: MenuBar, Toolbar and Breadcrumb are each replaced
+           independently via their own slot (`menu-items`, `toolbar-items`,
+           `breadcrumb-items`) - three separate custom components, three
+           separate slots, all still shown (showMenuBar/showToolbar/
+           showBreadcrumbBar stay true; the slot content replaces what's
+           *inside* each bar, it doesn't hide the bar itself). -->
+      <vue-finder
+        v-else
+        id="menubar_custom_all_slots"
+        :driver="driver"
+        :config="computedConfig"
+        :features="features"
+      >
+        <template #menu-items="{ menuItems }">
+          <div class="all-slots-chip">Custom MenuBar ({{ menuItems.length }} menus)</div>
+        </template>
+        <template #toolbar-items>
+          <div class="all-slots-chip">Custom Toolbar</div>
+        </template>
+        <template #breadcrumb-items>
+          <div class="all-slots-chip">Custom Breadcrumb</div>
+        </template>
+      </vue-finder>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.menubar-customization-example {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.menubar-customization-example__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.menubar-customization-example__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.menubar-customization-example__option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.menubar-customization-example__viewer {
+  flex: 1;
+  min-height: 480px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.menubar-chip {
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.all-slots-chip {
+  display: flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #4338ca;
+  background: #eef2ff;
+  border-bottom: 1px solid #e0e7ff;
+}
+</style>

--- a/src/__tests__/Vuefinder.spec.ts
+++ b/src/__tests__/Vuefinder.spec.ts
@@ -525,4 +525,141 @@ describe('VueFinder', () => {
       expect(() => useApp(testId)).toThrow();
     });
   });
+
+  describe('MenuBar customization', () => {
+    it('renders the default File/Edit/View/Go/Help menu when no custom slots are provided', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'menubar-default' },
+        global: defaultGlobal,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const labels = wrapper
+        .findAll('.vuefinder__menubar__label')
+        .map((label) => label.text());
+      expect(labels).toEqual(['File', 'Edit', 'View', 'Go', 'Help']);
+
+      wrapper.unmount();
+    });
+
+    it('replaces the default rendering via the "menu-items" scoped slot, keeping the same menuItems data', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'menubar-menu-items-slot' },
+        global: defaultGlobal,
+        slots: {
+          'menu-items': `<template #menu-items="{ menuItems }">
+            <div class="custom-menu-items">{{ menuItems.map((m) => m.id).join(',') }}</div>
+          </template>`,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const custom = wrapper.find('.custom-menu-items');
+      expect(custom.exists()).toBe(true);
+      expect(custom.text()).toBe('file,edit,view,go,help');
+
+      // Default per-menu rendering must be fully replaced, not just supplemented.
+      expect(wrapper.findAll('.vuefinder__menubar__label').length).toBe(0);
+
+      wrapper.unmount();
+    });
+
+    it('adds extra content via "menubar-start" and "menubar-end" without removing the default menus', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'menubar-start-end-slot' },
+        global: defaultGlobal,
+        slots: {
+          'menubar-start': `<div class="custom-start">Start</div>`,
+          'menubar-end': `<div class="custom-end">End</div>`,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wrapper.find('.custom-start').exists()).toBe(true);
+      expect(wrapper.find('.custom-end').exists()).toBe(true);
+
+      const labels = wrapper
+        .findAll('.vuefinder__menubar__label')
+        .map((label) => label.text());
+      expect(labels).toEqual(['File', 'Edit', 'View', 'Go', 'Help']);
+
+      wrapper.unmount();
+    });
+
+    it('hides the default Breadcrumb via config.showBreadcrumbBar, so a "menu-items" bar can fully replace it', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: {
+          ...defaultProps,
+          id: 'menubar-hides-breadcrumb',
+          config: { showBreadcrumbBar: false },
+        },
+        global: defaultGlobal,
+        slots: {
+          'menu-items': `<template #menu-items>
+            <div class="custom-menu-items">custom bar</div>
+          </template>`,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wrapper.find('.custom-menu-items').exists()).toBe(true);
+      expect(wrapper.find('.vuefinder__breadcrumb__container').exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('Toolbar and Breadcrumb customization', () => {
+    it('replaces the default Toolbar rendering via the "toolbar-items" slot', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'toolbar-items-slot' },
+        global: defaultGlobal,
+        slots: {
+          'toolbar-items': `<div class="custom-toolbar">custom toolbar</div>`,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wrapper.find('.custom-toolbar').exists()).toBe(true);
+      expect(wrapper.find('.vuefinder__toolbar__actions').exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('replaces the default Breadcrumb rendering via the "breadcrumb-items" slot', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'breadcrumb-items-slot' },
+        global: defaultGlobal,
+        slots: {
+          'breadcrumb-items': `<div class="custom-breadcrumb">custom breadcrumb</div>`,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wrapper.find('.custom-breadcrumb').exists()).toBe(true);
+      expect(wrapper.find('.vuefinder__breadcrumb__path-container').exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('keeps the default Toolbar/Breadcrumb when no slot content is provided', async () => {
+      const wrapper = mount(VueFinderProvider, {
+        props: { ...defaultProps, id: 'toolbar-breadcrumb-default' },
+        global: defaultGlobal,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wrapper.find('.vuefinder__toolbar__actions').exists()).toBe(true);
+      expect(wrapper.find('.vuefinder__breadcrumb__container').exists()).toBe(true);
+
+      wrapper.unmount();
+    });
+  });
 });

--- a/src/__tests__/Vuefinder.spec.ts
+++ b/src/__tests__/Vuefinder.spec.ts
@@ -631,19 +631,22 @@ describe('VueFinder', () => {
       wrapper.unmount();
     });
 
-    it('replaces the default Breadcrumb rendering via the "breadcrumb-items" slot', async () => {
+    it('replaces the action buttons (tree-view/go-up/refresh) via the "breadcrumb-actions" slot, keeping the path container', async () => {
       const wrapper = mount(VueFinderProvider, {
-        props: { ...defaultProps, id: 'breadcrumb-items-slot' },
+        props: { ...defaultProps, id: 'breadcrumb-actions-slot' },
         global: defaultGlobal,
         slots: {
-          'breadcrumb-items': `<div class="custom-breadcrumb">custom breadcrumb</div>`,
+          'breadcrumb-actions': `<div class="custom-breadcrumb-actions">custom actions</div>`,
         },
       });
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      expect(wrapper.find('.custom-breadcrumb').exists()).toBe(true);
-      expect(wrapper.find('.vuefinder__breadcrumb__path-container').exists()).toBe(false);
+      expect(wrapper.find('.custom-breadcrumb-actions').exists()).toBe(true);
+      // Default action buttons are replaced...
+      expect(wrapper.find('.vuefinder__breadcrumb__toggle-tree').exists()).toBe(false);
+      // ...but the complex path container itself is never slotted away.
+      expect(wrapper.find('.vuefinder__breadcrumb__path-container').exists()).toBe(true);
 
       wrapper.unmount();
     });

--- a/src/__tests__/useBreadcrumbActions.spec.ts
+++ b/src/__tests__/useBreadcrumbActions.spec.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { defineComponent, h, provide } from 'vue';
+import { mount } from '@vue/test-utils';
+import { atom } from 'nanostores';
+import { useBreadcrumbActions } from '../composables/useBreadcrumbActions';
+import { registerApp, unregisterApp, ServiceContainerIdKey } from '../composables/useApp';
+import type { App } from '../types';
+import type { ConfigState } from '../stores/config';
+
+const DEFAULT_CONFIG_STATE: ConfigState = {
+  view: 'grid',
+  theme: 'silver',
+  fullScreen: false,
+  showTreeView: false,
+  showHiddenFiles: true,
+  metricUnits: false,
+  showThumbnails: true,
+  persist: false,
+  path: '',
+  pinnedFolders: [],
+  notificationsEnabled: true,
+  expandTreeByDefault: false,
+  expandedTreePaths: [],
+  initialPath: null,
+  maxFileSize: null,
+  loadingIndicator: 'circular',
+  showMenuBar: true,
+  showToolbar: true,
+  showBreadcrumbBar: true,
+  gridItemWidth: 96,
+  gridItemHeight: 80,
+  gridItemGap: 8,
+  gridIconSize: 48,
+  listItemHeight: 32,
+  listItemGap: 2,
+  listIconSize: 16,
+  notificationPosition: 'bottom-center',
+  notificationDuration: 3000,
+  notificationVisibleToasts: 4,
+  notificationRichColors: true,
+};
+
+// A plain in-memory config store (no `@nanostores/persistent`/localStorage
+// involved), since composable tests only need `state`/`get`/`set`/`toggle` to
+// behave like the real thing - a fresh `atom()` per test is simpler and more
+// isolated than mocking the persistence layer.
+function createMockConfigStore(overrides: Partial<ConfigState> = {}) {
+  const state = atom<ConfigState>({ ...DEFAULT_CONFIG_STATE, ...overrides });
+
+  return {
+    state,
+    get: <K extends keyof ConfigState>(key: K) => state.get()[key],
+    set: (keyOrPatch: any, value?: any) => {
+      if (typeof keyOrPatch === 'object' && keyOrPatch !== null) {
+        state.set({ ...state.get(), ...keyOrPatch });
+      } else {
+        state.set({ ...state.get(), [keyOrPatch]: value });
+      }
+    },
+    toggle: (key: keyof ConfigState) => {
+      state.set({ ...state.get(), [key]: !state.get()[key] });
+    },
+    all: () => state.get(),
+    init: () => {},
+    reset: () => {
+      state.set({ ...DEFAULT_CONFIG_STATE });
+    },
+  };
+}
+
+function createTestApp() {
+  const app = {
+    i18n: { t: (key: string) => key },
+    fs: {
+      path: atom({
+        storage: 'local',
+        path: 'local://docs/sub',
+        breadcrumb: [
+          { name: 'docs', path: 'local://docs' },
+          { name: 'sub', path: 'local://docs/sub' },
+        ],
+      }),
+    },
+    config: createMockConfigStore(),
+    adapter: {
+      invalidateListQuery: vi.fn(),
+      open: vi.fn(),
+    },
+  } as unknown as App;
+
+  return app;
+}
+
+function mountComposable<T>(id: string, setupFn: () => T) {
+  let result!: T;
+  const Child = defineComponent({
+    setup() {
+      result = setupFn();
+      return () => h('div');
+    },
+  });
+  const Parent = defineComponent({
+    setup() {
+      provide(ServiceContainerIdKey, id);
+      return () => h(Child);
+    },
+  });
+  const wrapper = mount(Parent);
+  return { wrapper, get result() {
+    return result;
+  } };
+}
+
+describe('useBreadcrumbActions', () => {
+  const id = 'breadcrumb-actions-test';
+
+  afterEach(() => {
+    unregisterApp(id);
+  });
+
+  it('exposes a reactive currentPath, for bars that replace Breadcrumb.vue entirely', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    expect(result.currentPath.value.path).toBe('local://docs/sub');
+
+    app.fs.path.set({ storage: 'local', path: 'local://docs/sub/deeper', breadcrumb: [] });
+    expect(result.currentPath.value.path).toBe('local://docs/sub/deeper');
+  });
+
+  it('refresh() invalidates and reopens the current path', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    result.refresh();
+
+    expect(app.adapter.invalidateListQuery).toHaveBeenCalledWith('local://docs/sub');
+    expect(app.adapter.open).toHaveBeenCalledWith('local://docs/sub');
+  });
+
+  it('goUp() opens the parent path from the breadcrumb trail', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    result.goUp();
+
+    expect(app.adapter.open).toHaveBeenCalledWith('local://docs');
+  });
+
+  it('goUp() falls back to the storage root when there is no parent breadcrumb', () => {
+    const app = createTestApp();
+    app.fs.path.set({ storage: 'local', path: 'local://', breadcrumb: [] });
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    result.goUp();
+
+    expect(app.adapter.open).toHaveBeenCalledWith('local://');
+  });
+
+  it('toggleTreeView() flips the showTreeView config flag', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    expect(app.config.get('showTreeView')).toBe(false);
+    result.toggleTreeView();
+    expect(app.config.get('showTreeView')).toBe(true);
+  });
+
+  it('goTo() opens an arbitrary path, e.g. reused from a merged menu/breadcrumb bar', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    result.goTo('local://elsewhere');
+
+    expect(app.adapter.open).toHaveBeenCalledWith('local://elsewhere');
+  });
+
+  it('copyCurrentPath() writes the current path to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useBreadcrumbActions());
+
+    await result.copyCurrentPath();
+
+    expect(writeText).toHaveBeenCalledWith('local://docs/sub');
+  });
+});

--- a/src/__tests__/useMenuItems.spec.ts
+++ b/src/__tests__/useMenuItems.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { defineComponent, h, provide } from 'vue';
+import { mount } from '@vue/test-utils';
+import { atom } from 'nanostores';
+import { useMenuItems } from '../composables/useMenuItems';
+import { registerApp, unregisterApp, ServiceContainerIdKey } from '../composables/useApp';
+import type { App, DirEntry } from '../types';
+import type { ConfigState } from '../stores/config';
+
+function file(basename: string, type: 'file' | 'dir' = 'file'): DirEntry {
+  return {
+    storage: 'local',
+    dir: 'local://',
+    basename,
+    extension: type === 'file' ? (basename.split('.').pop() ?? '') : '',
+    path: `local://${basename}`,
+    type,
+    file_size: type === 'file' ? 1 : null,
+    last_modified: Date.now(),
+    mime_type: type === 'file' ? 'application/zip' : null,
+    visibility: 'public',
+  };
+}
+
+const DEFAULT_CONFIG_STATE: ConfigState = {
+  view: 'grid',
+  theme: 'silver',
+  fullScreen: false,
+  showTreeView: false,
+  showHiddenFiles: true,
+  metricUnits: false,
+  showThumbnails: true,
+  persist: false,
+  path: '',
+  pinnedFolders: [],
+  notificationsEnabled: true,
+  expandTreeByDefault: false,
+  expandedTreePaths: [],
+  initialPath: null,
+  maxFileSize: null,
+  loadingIndicator: 'circular',
+  showMenuBar: true,
+  showToolbar: true,
+  showBreadcrumbBar: true,
+  gridItemWidth: 96,
+  gridItemHeight: 80,
+  gridItemGap: 8,
+  gridIconSize: 48,
+  listItemHeight: 32,
+  listItemGap: 2,
+  listIconSize: 16,
+  notificationPosition: 'bottom-center',
+  notificationDuration: 3000,
+  notificationVisibleToasts: 4,
+  notificationRichColors: true,
+};
+
+// A plain in-memory config store (no `@nanostores/persistent`/localStorage
+// involved), since composable tests only need `state`/`get`/`set`/`toggle` to
+// behave like the real thing - a fresh `atom()` per test is simpler and more
+// isolated than mocking the persistence layer.
+function createMockConfigStore(overrides: Partial<ConfigState> = {}) {
+  const state = atom<ConfigState>({ ...DEFAULT_CONFIG_STATE, ...overrides });
+
+  return {
+    state,
+    get: <K extends keyof ConfigState>(key: K) => state.get()[key],
+    set: (keyOrPatch: any, value?: any) => {
+      if (typeof keyOrPatch === 'object' && keyOrPatch !== null) {
+        state.set({ ...state.get(), ...keyOrPatch });
+      } else {
+        state.set({ ...state.get(), [keyOrPatch]: value });
+      }
+    },
+    toggle: (key: keyof ConfigState) => {
+      state.set({ ...state.get(), [key]: !state.get()[key] });
+    },
+    all: () => state.get(),
+    init: () => {},
+    reset: () => {
+      state.set({ ...DEFAULT_CONFIG_STATE });
+    },
+  };
+}
+
+function createTestApp(overrides: { features?: Record<string, boolean> } = {}) {
+  const app = {
+    i18n: { t: (key: string) => key },
+    fs: {
+      path: atom({ storage: 'local', breadcrumb: [], path: 'local://' }),
+      selectedItems: atom<DirEntry[]>([]),
+      storages: atom<string[]>(['local']),
+      canGoForward: atom(false),
+      canGoBack: atom(false),
+      goForward: vi.fn(),
+      goBack: vi.fn(),
+      selectAll: vi.fn(),
+      clearSelection: vi.fn(),
+      setClipboard: vi.fn(),
+      getClipboard: vi.fn(() => ({ type: null, items: new Set() })),
+    },
+    config: createMockConfigStore(),
+    modal: { open: vi.fn(), close: vi.fn() },
+    adapter: {
+      invalidateListQuery: vi.fn(),
+      open: vi.fn(),
+      getDownloadUrl: vi.fn(() => 'https://example.test/download'),
+    },
+    emitter: { emit: vi.fn() },
+    features: { newfolder: true, newfile: true, upload: true, search: true, archive: true, ...overrides.features },
+    selectionMode: 'multiple',
+  } as unknown as App;
+
+  return app;
+}
+
+// Runs `setupFn` inside a real component tree so `useApp()` (inject-based)
+// resolves the given VueFinder id, mirroring how MenuBar.vue consumes it.
+function mountComposable<T>(id: string, setupFn: () => T) {
+  let result!: T;
+  const Child = defineComponent({
+    setup() {
+      result = setupFn();
+      return () => h('div');
+    },
+  });
+  const Parent = defineComponent({
+    setup() {
+      provide(ServiceContainerIdKey, id);
+      return () => h(Child);
+    },
+  });
+  const wrapper = mount(Parent);
+  return { wrapper, get result() {
+    return result;
+  } };
+}
+
+describe('useMenuItems', () => {
+  const id = 'menu-items-test';
+
+  afterEach(() => {
+    unregisterApp(id);
+  });
+
+  it('builds the default File/Edit/View/Go/Help structure', () => {
+    registerApp(id, createTestApp());
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    expect(result.menuItems.value.map((m) => m.id)).toEqual(['file', 'edit', 'view', 'go', 'help']);
+  });
+
+  it('hides feature-gated items when the feature is disabled', () => {
+    registerApp(id, createTestApp({ features: { newfolder: false } }));
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    const fileMenu = result.menuItems.value.find((m) => m.id === 'file')!;
+    const newFolderItem = fileMenu.items!.find((i) => i.id === 'new-folder')!;
+
+    expect(newFolderItem.hidden!()).toBe(true);
+  });
+
+  it('reacts to selection changes for single-item actions like rename', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    const editMenu = () => result.menuItems.value.find((m) => m.id === 'edit')!;
+    const renameItem = () => editMenu().items!.find((i) => i.id === 'rename')!;
+
+    expect(renameItem().enabled!()).toBe(false);
+
+    app.fs.selectedItems.set([file('a.txt')]);
+    expect(renameItem().enabled!()).toBe(true);
+
+    app.fs.selectedItems.set([file('a.txt'), file('b.txt')]);
+    expect(renameItem().enabled!()).toBe(false);
+  });
+
+  it('reuses the exact same action as MenuBar.vue when opening a modal', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    app.fs.selectedItems.set([file('archive.zip')]);
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    const fileMenu = result.menuItems.value.find((m) => m.id === 'file')!;
+    const archiveItem = fileMenu.items!.find((i) => i.id === 'archive')!;
+
+    archiveItem.action!();
+
+    expect(app.modal.open).toHaveBeenCalledTimes(1);
+    expect(app.modal.open).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ items: app.fs.selectedItems.get() })
+    );
+  });
+
+  it('the "refresh" view action invalidates and reopens the current path', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    const viewMenu = result.menuItems.value.find((m) => m.id === 'view')!;
+    viewMenu.items!.find((i) => i.id === 'refresh')!.action!();
+
+    expect(app.adapter.invalidateListQuery).toHaveBeenCalledWith('local://');
+    expect(app.adapter.open).toHaveBeenCalledWith('local://');
+  });
+
+  it('the "grid-view" action updates config and "checked" reflects the current view', () => {
+    const app = createTestApp();
+    registerApp(id, app);
+    const { result } = mountComposable(id, () => useMenuItems());
+
+    const viewMenu = () => result.menuItems.value.find((m) => m.id === 'view')!;
+    const listViewItem = viewMenu().items!.find((i) => i.id === 'list-view')!;
+
+    expect(listViewItem.checked!()).toBe(false);
+    listViewItem.action!();
+    expect(app.config.get('view')).toBe('list');
+    expect(viewMenu().items!.find((i) => i.id === 'list-view')!.checked!()).toBe(true);
+  });
+});

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -2,7 +2,6 @@
 import { nextTick, onMounted, onUnmounted, ref, watch, computed } from 'vue';
 import { useStore } from '@nanostores/vue';
 import useDebouncedRef from '../composables/useDebouncedRef';
-import { copyPath } from '../utils/clipboard';
 import RefreshSVG from '../assets/icons/refresh.svg';
 import GoUpSVG from '../assets/icons/go_up.svg';
 import CloseSVG from '../assets/icons/close.svg';
@@ -19,10 +18,10 @@ import type { ConfigState } from '../stores/config';
 import type { StoreValue } from 'nanostores';
 import type { CurrentPathState } from '../stores/files';
 import { useApp } from '../composables/useApp';
+import { useBreadcrumbActions } from '../composables/useBreadcrumbActions';
 import type { DirEntry } from '../types';
-import { createNotifier } from '../utils/notify';
 const app = useApp();
-const notify = createNotifier(app);
+const breadcrumbActions = useBreadcrumbActions();
 
 const { t } = app.i18n;
 const fs = app.fs;
@@ -166,16 +165,12 @@ function getBreadcrumb(index: number | null = null) {
 }
 
 const handleRefresh = () => {
-  app.adapter.invalidateListQuery(currentPath.value.path);
-  app.adapter.open(currentPath.value.path);
+  breadcrumbActions.refresh();
 };
 
 const handleGoUp = () => {
   if (visibleBreadcrumbs.value.length > 0) {
-    app.adapter.open(
-      allBreadcrumbs.value[allBreadcrumbs.value.length - 2]?.path ??
-        (currentPath.value?.storage ?? 'local') + '://'
-    );
+    breadcrumbActions.goUp();
   }
 };
 
@@ -209,7 +204,7 @@ const vClickOutside = {
  * Tree View
  */
 const toggleTreeView = () => {
-  config.toggle('showTreeView');
+  breadcrumbActions.toggleTreeView();
 };
 
 /**
@@ -239,8 +234,7 @@ const togglePathCopyMode = () => {
 };
 
 const copyPathToClipboard = async () => {
-  await copyPath(currentPath.value?.path || '');
-  notify.success(t('Path copied to clipboard'));
+  await breadcrumbActions.copyCurrentPath();
 };
 
 const exitPathCopyMode = () => {
@@ -249,123 +243,132 @@ const exitPathCopyMode = () => {
 </script>
 
 <template>
-  <div class="vuefinder__breadcrumb__container">
-    <span :title="t('Toggle Tree View')">
-      <ListTreeSVG
-        class="vuefinder__breadcrumb__toggle-tree"
-        :class="configStore.showTreeView ? 'vuefinder__breadcrumb__toggle-tree--active' : ''"
-        @click="toggleTreeView"
-      />
-    </span>
-
-    <span :title="t('Go up a directory')">
-      <GoUpSVG
-        :class="
-          allBreadcrumbs.length
-            ? 'vuefinder__breadcrumb__go-up--active'
-            : 'vuefinder__breadcrumb__go-up--inactive'
-        "
-        v-on="allBreadcrumbs.length ? dragNDrop.events(getBreadcrumb() as unknown as any) : {}"
-        @click="handleGoUp"
-      />
-    </span>
-
-    <span v-if="!fs.isLoading()" :title="t('Refresh')">
-      <RefreshSVG @click="handleRefresh" />
-    </span>
-    <span v-else :title="t('Cancel')">
-      <CloseSVG @click="app.emitter.emit('vf-fetch-abort')" />
-    </span>
-
-    <div v-show="!showPathCopyMode" class="vuefinder__breadcrumb__path-container">
-      <div>
-        <HomeSVG
-          class="vuefinder__breadcrumb__home-icon"
-          v-on="dragNDrop.events(getBreadcrumb(-1))"
-          @click.stop="app.adapter.open(currentPath.storage + '://')"
+  <!-- Extension point: replace the entire breadcrumb bar with a custom
+       component. Fallback below is the default rendering; a custom
+       component can call `useBreadcrumbActions()`/`useApp()` itself to
+       reuse the same actions (refresh, go up, toggle tree, copy path,
+       current path) instead of relying on slot props. -->
+  <slot name="breadcrumb-items">
+    <div class="vuefinder__breadcrumb__container">
+      <span :title="t('Toggle Tree View')">
+        <ListTreeSVG
+          class="vuefinder__breadcrumb__toggle-tree"
+          :class="configStore.showTreeView ? 'vuefinder__breadcrumb__toggle-tree--active' : ''"
+          @click="toggleTreeView"
         />
-      </div>
-
-      <div class="vuefinder__breadcrumb__list">
-        <div
-          v-if="hiddenBreadcrumbs.length"
-          v-click-outside="handleClickOutside"
-          class="vuefinder__breadcrumb__hidden-list"
-        >
-          <div class="vuefinder__breadcrumb__separator">/</div>
-          <div class="relative">
-            <span
-              class="vuefinder__breadcrumb__hidden-toggle"
-              @dragenter="handleHiddenBreadcrumbsToggle($event, true)"
-              @click.stop="handleHiddenBreadcrumbsToggle"
-            >
-              <DotsSVG class="vuefinder__breadcrumb__hidden-toggle-icon" />
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <div
-        ref="breadcrumbContainer"
-        class="vuefinder__breadcrumb__visible-list pointer-events-none"
-      >
-        <div v-for="(item, index) in visibleBreadcrumbs" :key="index">
-          <span class="vuefinder__breadcrumb__separator">/</span>
-          <span
-            class="vuefinder__breadcrumb__item pointer-events-auto"
-            :title="(item as any).basename"
-            v-on="dragNDrop.events(item as any)"
-            @click.stop="app.adapter.open((item as any).path)"
-            >{{ (item as any).name }}</span
-          >
-        </div>
-      </div>
-
-      <LoadingSVG v-if="config.get('loadingIndicator') === 'circular' && loading" />
-      <span :title="t('Toggle Path Copy Mode')" @click="togglePathCopyMode">
-        <ToggleSVG class="vuefinder__breadcrumb__toggle-icon" />
       </span>
-    </div>
 
-    <!-- Path Copy Mode -->
-    <div v-show="showPathCopyMode" class="vuefinder__breadcrumb__path-mode">
-      <div class="vuefinder__breadcrumb__path-mode-content">
-        <div :title="t('Copy Path')">
-          <CopySVG class="vuefinder__breadcrumb__copy-icon" @click="copyPathToClipboard" />
-        </div>
-        <div class="vuefinder__breadcrumb__path-text">{{ currentPath.path }}</div>
-        <div :title="t('Exit')">
-          <ExitSVG class="vuefinder__breadcrumb__exit-icon" @click="exitPathCopyMode" />
-        </div>
-      </div>
-    </div>
+      <span :title="t('Go up a directory')">
+        <GoUpSVG
+          :class="
+            allBreadcrumbs.length
+              ? 'vuefinder__breadcrumb__go-up--active'
+              : 'vuefinder__breadcrumb__go-up--inactive'
+          "
+          v-on="allBreadcrumbs.length ? dragNDrop.events(getBreadcrumb() as unknown as any) : {}"
+          @click="handleGoUp"
+        />
+      </span>
 
-    <Teleport to="body">
-      <div>
-        <div
-          v-show="showHiddenBreadcrumbs"
-          :style="{
-            position: 'absolute',
-            top: mousePosition.y + 'px',
-            left: mousePosition.x + 'px',
-          }"
-          class="vuefinder__themer vuefinder__breadcrumb__hidden-dropdown"
-          :data-theme="app.theme.current"
-        >
+      <span v-if="!fs.isLoading()" :title="t('Refresh')">
+        <RefreshSVG @click="handleRefresh" />
+      </span>
+      <span v-else :title="t('Cancel')">
+        <CloseSVG @click="app.emitter.emit('vf-fetch-abort')" />
+      </span>
+
+      <div v-show="!showPathCopyMode" class="vuefinder__breadcrumb__path-container">
+        <div>
+          <HomeSVG
+            class="vuefinder__breadcrumb__home-icon"
+            v-on="dragNDrop.events(getBreadcrumb(-1))"
+            @click.stop="app.adapter.open(currentPath.storage + '://')"
+          />
+        </div>
+
+        <div class="vuefinder__breadcrumb__list">
           <div
-            v-for="(item, index) in hiddenBreadcrumbs"
-            :key="index"
-            class="vuefinder__breadcrumb__hidden-item"
-            v-on="dragNDrop.events(item as any)"
-            @click="handleHiddenBreadcrumbsClick(item as any)"
+            v-if="hiddenBreadcrumbs.length"
+            v-click-outside="handleClickOutside"
+            class="vuefinder__breadcrumb__hidden-list"
           >
-            <div class="vuefinder__breadcrumb__hidden-item-content">
-              <span><FolderSVG class="vuefinder__breadcrumb__hidden-item-icon" /></span>
-              <span class="vuefinder__breadcrumb__hidden-item-text">{{ (item as any).name }}</span>
+            <div class="vuefinder__breadcrumb__separator">/</div>
+            <div class="relative">
+              <span
+                class="vuefinder__breadcrumb__hidden-toggle"
+                @dragenter="handleHiddenBreadcrumbsToggle($event, true)"
+                @click.stop="handleHiddenBreadcrumbsToggle"
+              >
+                <DotsSVG class="vuefinder__breadcrumb__hidden-toggle-icon" />
+              </span>
             </div>
           </div>
         </div>
+
+        <div
+          ref="breadcrumbContainer"
+          class="vuefinder__breadcrumb__visible-list pointer-events-none"
+        >
+          <div v-for="(item, index) in visibleBreadcrumbs" :key="index">
+            <span class="vuefinder__breadcrumb__separator">/</span>
+            <span
+              class="vuefinder__breadcrumb__item pointer-events-auto"
+              :title="(item as any).basename"
+              v-on="dragNDrop.events(item as any)"
+              @click.stop="app.adapter.open((item as any).path)"
+              >{{ (item as any).name }}</span
+            >
+          </div>
+        </div>
+
+        <LoadingSVG v-if="config.get('loadingIndicator') === 'circular' && loading" />
+        <span :title="t('Toggle Path Copy Mode')" @click="togglePathCopyMode">
+          <ToggleSVG class="vuefinder__breadcrumb__toggle-icon" />
+        </span>
       </div>
-    </Teleport>
-  </div>
+
+      <!-- Path Copy Mode -->
+      <div v-show="showPathCopyMode" class="vuefinder__breadcrumb__path-mode">
+        <div class="vuefinder__breadcrumb__path-mode-content">
+          <div :title="t('Copy Path')">
+            <CopySVG class="vuefinder__breadcrumb__copy-icon" @click="copyPathToClipboard" />
+          </div>
+          <div class="vuefinder__breadcrumb__path-text">{{ currentPath.path }}</div>
+          <div :title="t('Exit')">
+            <ExitSVG class="vuefinder__breadcrumb__exit-icon" @click="exitPathCopyMode" />
+          </div>
+        </div>
+      </div>
+
+      <Teleport to="body">
+        <div>
+          <div
+            v-show="showHiddenBreadcrumbs"
+            :style="{
+              position: 'absolute',
+              top: mousePosition.y + 'px',
+              left: mousePosition.x + 'px',
+            }"
+            class="vuefinder__themer vuefinder__breadcrumb__hidden-dropdown"
+            :data-theme="app.theme.current"
+          >
+            <div
+              v-for="(item, index) in hiddenBreadcrumbs"
+              :key="index"
+              class="vuefinder__breadcrumb__hidden-item"
+              v-on="dragNDrop.events(item as any)"
+              @click="handleHiddenBreadcrumbsClick(item as any)"
+            >
+              <div class="vuefinder__breadcrumb__hidden-item-content">
+                <span><FolderSVG class="vuefinder__breadcrumb__hidden-item-icon" /></span>
+                <span class="vuefinder__breadcrumb__hidden-item-text">{{
+                  (item as any).name
+                }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Teleport>
+    </div>
+  </slot>
 </template>

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -243,13 +243,16 @@ const exitPathCopyMode = () => {
 </script>
 
 <template>
-  <!-- Extension point: replace the entire breadcrumb bar with a custom
-       component. Fallback below is the default rendering; a custom
-       component can call `useBreadcrumbActions()`/`useApp()` itself to
-       reuse the same actions (refresh, go up, toggle tree, copy path,
-       current path) instead of relying on slot props. -->
-  <slot name="breadcrumb-items">
-    <div class="vuefinder__breadcrumb__container">
+  <div class="vuefinder__breadcrumb__container">
+    <!-- Extension point: replace the action buttons shown before the path
+         (tree-view toggle, go up, refresh/cancel). Fallback below is the
+         default rendering. The path container itself is intentionally not
+         slotted - it handles overflow measurement, drag & drop, the
+         hidden-item dropdown, and path-copy mode, and isn't meant to be
+         reimplemented. A custom component can call
+         `useBreadcrumbActions()`/`useApp()` itself to reuse the same
+         actions (refresh, go up, toggle tree). -->
+    <slot name="breadcrumb-actions">
       <span :title="t('Toggle Tree View')">
         <ListTreeSVG
           class="vuefinder__breadcrumb__toggle-tree"
@@ -276,99 +279,97 @@ const exitPathCopyMode = () => {
       <span v-else :title="t('Cancel')">
         <CloseSVG @click="app.emitter.emit('vf-fetch-abort')" />
       </span>
+    </slot>
 
-      <div v-show="!showPathCopyMode" class="vuefinder__breadcrumb__path-container">
-        <div>
-          <HomeSVG
-            class="vuefinder__breadcrumb__home-icon"
-            v-on="dragNDrop.events(getBreadcrumb(-1))"
-            @click.stop="app.adapter.open(currentPath.storage + '://')"
-          />
-        </div>
+    <div v-show="!showPathCopyMode" class="vuefinder__breadcrumb__path-container">
+      <div>
+        <HomeSVG
+          class="vuefinder__breadcrumb__home-icon"
+          v-on="dragNDrop.events(getBreadcrumb(-1))"
+          @click.stop="app.adapter.open(currentPath.storage + '://')"
+        />
+      </div>
 
-        <div class="vuefinder__breadcrumb__list">
-          <div
-            v-if="hiddenBreadcrumbs.length"
-            v-click-outside="handleClickOutside"
-            class="vuefinder__breadcrumb__hidden-list"
-          >
-            <div class="vuefinder__breadcrumb__separator">/</div>
-            <div class="relative">
-              <span
-                class="vuefinder__breadcrumb__hidden-toggle"
-                @dragenter="handleHiddenBreadcrumbsToggle($event, true)"
-                @click.stop="handleHiddenBreadcrumbsToggle"
-              >
-                <DotsSVG class="vuefinder__breadcrumb__hidden-toggle-icon" />
-              </span>
-            </div>
-          </div>
-        </div>
-
+      <div class="vuefinder__breadcrumb__list">
         <div
-          ref="breadcrumbContainer"
-          class="vuefinder__breadcrumb__visible-list pointer-events-none"
+          v-if="hiddenBreadcrumbs.length"
+          v-click-outside="handleClickOutside"
+          class="vuefinder__breadcrumb__hidden-list"
         >
-          <div v-for="(item, index) in visibleBreadcrumbs" :key="index">
-            <span class="vuefinder__breadcrumb__separator">/</span>
+          <div class="vuefinder__breadcrumb__separator">/</div>
+          <div class="relative">
             <span
-              class="vuefinder__breadcrumb__item pointer-events-auto"
-              :title="(item as any).basename"
-              v-on="dragNDrop.events(item as any)"
-              @click.stop="app.adapter.open((item as any).path)"
-              >{{ (item as any).name }}</span
+              class="vuefinder__breadcrumb__hidden-toggle"
+              @dragenter="handleHiddenBreadcrumbsToggle($event, true)"
+              @click.stop="handleHiddenBreadcrumbsToggle"
             >
-          </div>
-        </div>
-
-        <LoadingSVG v-if="config.get('loadingIndicator') === 'circular' && loading" />
-        <span :title="t('Toggle Path Copy Mode')" @click="togglePathCopyMode">
-          <ToggleSVG class="vuefinder__breadcrumb__toggle-icon" />
-        </span>
-      </div>
-
-      <!-- Path Copy Mode -->
-      <div v-show="showPathCopyMode" class="vuefinder__breadcrumb__path-mode">
-        <div class="vuefinder__breadcrumb__path-mode-content">
-          <div :title="t('Copy Path')">
-            <CopySVG class="vuefinder__breadcrumb__copy-icon" @click="copyPathToClipboard" />
-          </div>
-          <div class="vuefinder__breadcrumb__path-text">{{ currentPath.path }}</div>
-          <div :title="t('Exit')">
-            <ExitSVG class="vuefinder__breadcrumb__exit-icon" @click="exitPathCopyMode" />
+              <DotsSVG class="vuefinder__breadcrumb__hidden-toggle-icon" />
+            </span>
           </div>
         </div>
       </div>
 
-      <Teleport to="body">
-        <div>
-          <div
-            v-show="showHiddenBreadcrumbs"
-            :style="{
-              position: 'absolute',
-              top: mousePosition.y + 'px',
-              left: mousePosition.x + 'px',
-            }"
-            class="vuefinder__themer vuefinder__breadcrumb__hidden-dropdown"
-            :data-theme="app.theme.current"
+      <div
+        ref="breadcrumbContainer"
+        class="vuefinder__breadcrumb__visible-list pointer-events-none"
+      >
+        <div v-for="(item, index) in visibleBreadcrumbs" :key="index">
+          <span class="vuefinder__breadcrumb__separator">/</span>
+          <span
+            class="vuefinder__breadcrumb__item pointer-events-auto"
+            :title="(item as any).basename"
+            v-on="dragNDrop.events(item as any)"
+            @click.stop="app.adapter.open((item as any).path)"
+            >{{ (item as any).name }}</span
           >
-            <div
-              v-for="(item, index) in hiddenBreadcrumbs"
-              :key="index"
-              class="vuefinder__breadcrumb__hidden-item"
-              v-on="dragNDrop.events(item as any)"
-              @click="handleHiddenBreadcrumbsClick(item as any)"
-            >
-              <div class="vuefinder__breadcrumb__hidden-item-content">
-                <span><FolderSVG class="vuefinder__breadcrumb__hidden-item-icon" /></span>
-                <span class="vuefinder__breadcrumb__hidden-item-text">{{
-                  (item as any).name
-                }}</span>
-              </div>
+        </div>
+      </div>
+
+      <LoadingSVG v-if="config.get('loadingIndicator') === 'circular' && loading" />
+      <span :title="t('Toggle Path Copy Mode')" @click="togglePathCopyMode">
+        <ToggleSVG class="vuefinder__breadcrumb__toggle-icon" />
+      </span>
+    </div>
+
+    <!-- Path Copy Mode -->
+    <div v-show="showPathCopyMode" class="vuefinder__breadcrumb__path-mode">
+      <div class="vuefinder__breadcrumb__path-mode-content">
+        <div :title="t('Copy Path')">
+          <CopySVG class="vuefinder__breadcrumb__copy-icon" @click="copyPathToClipboard" />
+        </div>
+        <div class="vuefinder__breadcrumb__path-text">{{ currentPath.path }}</div>
+        <div :title="t('Exit')">
+          <ExitSVG class="vuefinder__breadcrumb__exit-icon" @click="exitPathCopyMode" />
+        </div>
+      </div>
+    </div>
+
+    <Teleport to="body">
+      <div>
+        <div
+          v-show="showHiddenBreadcrumbs"
+          :style="{
+            position: 'absolute',
+            top: mousePosition.y + 'px',
+            left: mousePosition.x + 'px',
+          }"
+          class="vuefinder__themer vuefinder__breadcrumb__hidden-dropdown"
+          :data-theme="app.theme.current"
+        >
+          <div
+            v-for="(item, index) in hiddenBreadcrumbs"
+            :key="index"
+            class="vuefinder__breadcrumb__hidden-item"
+            v-on="dragNDrop.events(item as any)"
+            @click="handleHiddenBreadcrumbsClick(item as any)"
+          >
+            <div class="vuefinder__breadcrumb__hidden-item-content">
+              <span><FolderSVG class="vuefinder__breadcrumb__hidden-item-icon" /></span>
+              <span class="vuefinder__breadcrumb__hidden-item-text">{{ (item as any).name }}</span>
             </div>
           </div>
         </div>
-      </Teleport>
-    </div>
-  </slot>
+      </div>
+    </Teleport>
+  </div>
 </template>

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -1,530 +1,29 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { useStore } from '@nanostores/vue';
-import { useFeature } from '../composables/useFeature';
-import type { DirEntry } from '../types';
-import { copyPath, copyDownloadUrl } from '../utils/clipboard';
-import { entryKey } from '../utils/entryKey';
-import ModalNewFolder from './modals/ModalNewFolder.vue';
-import ModalNewFile from './modals/ModalNewFile.vue';
-import ModalRename from './modals/ModalRename.vue';
-import ModalDelete from './modals/ModalDelete.vue';
-import ModalUpload from './modals/ModalUpload.vue';
-import ModalUnarchive from './modals/ModalUnarchive.vue';
-import ModalArchive from './modals/ModalArchive.vue';
-import ModalAbout from './modals/ModalAbout.vue';
-import ModalMove from './modals/ModalMove.vue';
-import ModalCopy from './modals/ModalCopy.vue';
-import ModalPreview from './modals/ModalPreview.vue';
-import ModalSearch from './modals/ModalSearch.vue';
-import ModalSettings from './modals/ModalSettings.vue';
-import ModalShortcuts from './modals/ModalShortcuts.vue';
-import ModalGoToFolder from './modals/ModalGoToFolder.vue';
-import { useApp } from '../composables/useApp';
-import { format as filesizeDefault, metricFormat as filesizeMetric } from '../utils/filesize';
-import { inject } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
+import { useMenuItems } from '../composables/useMenuItems';
 
-import type { StoreValue } from 'nanostores';
-import type { ConfigState } from '../stores/config';
-
-const app = useApp();
-const { enabled } = useFeature();
-
-const { t } = app?.i18n || { t: (key: string) => key };
-
-const fs = app?.fs;
-const config = app?.config;
-
-// Use nanostores reactive values for template reactivity
-const configState: StoreValue<ConfigState> = useStore(config.state);
-const selectedItems: StoreValue<DirEntry[]> = useStore(fs.selectedItems);
-const storages: StoreValue<string[]> = useStore(fs?.storages || []);
+const { menuItems } = useMenuItems();
 
 // Menu state
 const activeMenu = ref<string | null>(null);
 const isMenuOpen = ref(false);
 
-// Check if exit option should be shown
-const shouldShowExit = computed(() => {
-  const canClose = window.opener !== null || window.name !== '' || window.history.length <= 1;
-  return canClose;
-});
-
-// Make menu items reactive to language changes
-const menuItems = computed<any[]>(() => [
-  {
-    id: 'file',
-    label: t('File'),
-    items: [
-      {
-        id: 'new-folder',
-        label: t('New Folder'),
-        action: () => app?.modal?.open(ModalNewFolder, { items: selectedItems.value }),
-        hidden: () => !enabled('newfolder'),
-      },
-      {
-        id: 'new-file',
-        label: t('New File'),
-        action: () => app?.modal?.open(ModalNewFile, { items: selectedItems.value }),
-        hidden: () => !enabled('newfile'),
-      },
-      {
-        type: 'separator',
-        hidden: () => (!enabled('newfolder') && !enabled('newfile')) || !enabled('upload'),
-      },
-      {
-        id: 'upload',
-        label: t('Upload'),
-        action: () => app?.modal?.open(ModalUpload, { items: selectedItems.value }),
-        hidden: () => !enabled('upload'),
-      },
-      { type: 'separator', hidden: () => !enabled('search') },
-      {
-        id: 'search',
-        label: t('Search'),
-        action: () => app.modal.open(ModalSearch),
-        hidden: () => !enabled('search'),
-      },
-      { type: 'separator', hidden: () => !enabled('archive') && !enabled('unarchive') },
-      {
-        id: 'archive',
-        label: t('Archive'),
-        action: () => {
-          if (selectedItems.value.length > 0) {
-            app?.modal?.open(ModalArchive, { items: selectedItems.value });
-          }
-        },
-        enabled: () => selectedItems.value.length > 0,
-        hidden: () => !enabled('archive'),
-      },
-      {
-        id: 'unarchive',
-        label: t('Unarchive'),
-        action: () => {
-          if (
-            selectedItems.value.length === 1 &&
-            selectedItems.value[0]?.mime_type === 'application/zip'
-          ) {
-            app?.modal?.open(ModalUnarchive, { items: selectedItems.value });
-          }
-        },
-        enabled: () =>
-          selectedItems.value.length === 1 &&
-          selectedItems.value[0]?.mime_type === 'application/zip',
-        hidden: () => !enabled('unarchive'),
-      },
-      { type: 'separator', hidden: () => !enabled('preview') },
-      {
-        id: 'preview',
-        label: t('Preview'),
-        action: () => {
-          if (selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir') {
-            app?.modal?.open(ModalPreview, {
-              storage: fs?.path?.get()?.storage,
-              item: selectedItems.value[0],
-            });
-          }
-        },
-        enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
-        hidden: () => !enabled('preview'),
-      },
-      {
-        id: 'open-as',
-        label: t('Preview as'),
-        items: [
-          {
-            id: 'open-as-text',
-            label: t('Text'),
-            action: () =>
-              app?.modal?.open(ModalPreview, {
-                storage: fs?.path?.get()?.storage,
-                item: selectedItems.value[0],
-                forceType: 'text',
-              }),
-            enabled: () =>
-              selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
-          },
-          {
-            id: 'open-as-image',
-            label: t('Image'),
-            action: () =>
-              app?.modal?.open(ModalPreview, {
-                storage: fs?.path?.get()?.storage,
-                item: selectedItems.value[0],
-                forceType: 'image',
-              }),
-            enabled: () =>
-              selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
-          },
-        ],
-        enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
-        hidden: () => !enabled('preview'),
-      },
-      // Only show exit option if we can actually close the window
-      ...(shouldShowExit.value
-        ? [
-            { type: 'separator' },
-            {
-              id: 'exit',
-              label: t('Exit'),
-              action: () => {
-                try {
-                  window.close();
-                } catch (e) {
-                  // Window cannot be closed programmatically
-                }
-              },
-              enabled: () => true,
-            },
-          ]
-        : []),
-    ],
-  },
-  {
-    id: 'edit',
-    label: t('Edit'),
-    items: [
-      // Only show Select All and Deselect All in multiple selection mode
-      ...(app?.selectionMode === 'multiple'
-        ? [
-            {
-              id: 'select-all',
-              label: t('Select All'),
-              action: () =>
-                fs?.selectAll((app?.selectionMode as 'single' | 'multiple') || 'multiple', app),
-              enabled: () => true,
-            },
-            {
-              id: 'deselect',
-              label: t('Deselect All'),
-              action: () => fs?.clearSelection(),
-              enabled: () => selectedItems.value.length > 0,
-            },
-            { type: 'separator' },
-          ]
-        : []),
-      ...(enabled('copy')
-        ? [
-            {
-              id: 'cut',
-              label: t('Cut'),
-              action: () => {
-                if (selectedItems.value.length > 0) {
-                  fs?.setClipboard(
-                    'cut',
-                    new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
-                  );
-                }
-              },
-              enabled: () => selectedItems.value.length > 0,
-            },
-            {
-              id: 'copy',
-              label: t('Copy'),
-              action: () => {
-                if (selectedItems.value.length > 0) {
-                  fs?.setClipboard(
-                    'copy',
-                    new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
-                  );
-                }
-              },
-              enabled: () => selectedItems.value.length > 0,
-            },
-            {
-              id: 'paste',
-              label: t('Paste'),
-              action: () => {
-                const clipboard = fs?.getClipboard();
-                if (clipboard?.items?.size > 0) {
-                  app?.modal?.open(clipboard.type === 'cut' ? ModalMove : ModalCopy, {
-                    items: { from: Array.from(clipboard.items), to: fs?.path?.get() },
-                  });
-                }
-              },
-              enabled: () => {
-                const clipboard = fs?.getClipboard();
-                return clipboard?.items?.size > 0;
-              },
-            },
-          ]
-        : []),
-      ...(enabled('move')
-        ? [
-            {
-              id: 'move',
-              label: t('Move files'),
-              action: () => {
-                if (selectedItems.value.length > 0) {
-                  const fs = app?.fs;
-                  const target = {
-                    storage: fs?.path?.get()?.storage || '',
-                    path: fs?.path?.get()?.path || '',
-                    type: 'dir' as const,
-                  };
-                  app?.modal?.open(ModalMove, { items: { from: selectedItems.value, to: target } });
-                }
-              },
-              enabled: () => selectedItems.value.length > 0,
-            },
-            { type: 'separator' },
-          ]
-        : []),
-      {
-        id: 'copy-path',
-        label: t('Copy Path'),
-        action: async () => {
-          if (selectedItems.value.length === 1) {
-            // Copy selected item's path
-            const item = selectedItems.value[0];
-            await copyPath(item.path);
-          } else {
-            // Copy current path if no item selected
-            const currentPath = fs?.path?.get();
-            if (currentPath?.path) {
-              await copyPath(currentPath.path);
-            }
-          }
-        },
-        enabled: () => true, // Her zaman aktif
-      },
-      {
-        id: 'copy-download-url',
-        label: t('Copy Download URL'),
-        action: async () => {
-          if (selectedItems.value.length === 1) {
-            const item = selectedItems.value[0];
-            const storage = fs?.path?.get()?.storage ?? 'local';
-            const downloadUrl = app?.adapter?.getDownloadUrl({ path: item.path });
-            if (downloadUrl) {
-              await copyDownloadUrl(downloadUrl);
-            }
-          }
-        },
-        enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
-      },
-      { type: 'separator', hidden: () => !enabled('rename') && !enabled('delete') },
-      {
-        id: 'rename',
-        label: t('Rename'),
-        action: () => {
-          if (selectedItems.value.length === 1) {
-            app?.modal?.open(ModalRename, { items: selectedItems.value });
-          }
-        },
-        enabled: () => selectedItems.value.length === 1,
-        hidden: () => !enabled('rename'),
-      },
-      {
-        id: 'delete',
-        label: t('Delete'),
-        action: () => {
-          if (selectedItems.value.length > 0) {
-            app?.modal?.open(ModalDelete, { items: selectedItems.value });
-          }
-        },
-        enabled: () => selectedItems.value.length > 0,
-        hidden: () => !enabled('delete'),
-      },
-    ],
-  },
-  {
-    id: 'view',
-    label: t('View'),
-    items: [
-      {
-        id: 'refresh',
-        label: t('Refresh'),
-        action: () => {
-          app.adapter.invalidateListQuery(fs.path.get().path);
-          app.adapter.open(fs.path.get().path);
-        },
-        enabled: () => true,
-      },
-      { type: 'separator' },
-      {
-        id: 'grid-view',
-        label: t('Grid View'),
-        action: () => config?.set('view', 'grid'),
-        enabled: () => true,
-        checked: () => configState.value?.view === 'grid',
-      },
-      {
-        id: 'list-view',
-        label: t('List View'),
-        action: () => config?.set('view', 'list'),
-        enabled: () => true,
-        checked: () => configState.value?.view === 'list',
-      },
-      { type: 'separator' },
-      {
-        id: 'tree-view',
-        label: t('Tree View'),
-        action: () => config?.toggle('showTreeView'),
-        enabled: () => true,
-        checked: () => configState.value?.showTreeView,
-      },
-      {
-        id: 'thumbnails',
-        label: t('Show Thumbnails'),
-        action: () => config?.toggle('showThumbnails'),
-        enabled: () => true,
-        checked: () => configState.value?.showThumbnails,
-      },
-      {
-        id: 'show-hidden-files',
-        label: t('Show Hidden Files'),
-        action: () => config?.toggle('showHiddenFiles'),
-        enabled: () => true,
-        checked: () => configState.value?.showHiddenFiles,
-      },
-      { type: 'separator', hidden: () => !enabled('fullscreen') },
-      {
-        id: 'fullscreen',
-        label: t('Full Screen'),
-        action: () => config?.toggle('fullScreen'),
-        enabled: () => enabled('fullscreen'),
-        checked: () => configState.value?.fullScreen,
-        hidden: () => !enabled('fullscreen'),
-      },
-      { type: 'separator' },
-      {
-        id: 'persist-path',
-        label: t('Persist Path'),
-        action: () => {
-          config?.toggle('persist');
-          app.emitter.emit('vf-persist-path-saved');
-        },
-        enabled: () => true,
-        checked: () => configState.value?.persist,
-      },
-      {
-        id: 'metric-units',
-        label: t('Metric Units'),
-        action: () => {
-          config?.toggle('metricUnits');
-          app.filesize = config?.get('metricUnits') ? filesizeMetric : filesizeDefault;
-          app.emitter.emit('vf-metric-units-saved');
-        },
-        enabled: () => true,
-        checked: () => configState.value?.metricUnits,
-      },
-    ],
-  },
-  {
-    id: 'go',
-    label: t('Go'),
-    items: [
-      ...(enabled('history')
-        ? [
-            {
-              id: 'forward',
-              label: t('Forward'),
-              action: () => {
-                fs?.goForward();
-                const pathInfo = fs?.path?.get();
-                if (pathInfo?.path) {
-                  app?.adapter.open(pathInfo.path);
-                }
-              },
-              enabled: () => fs?.canGoForward?.get() ?? false,
-            },
-            {
-              id: 'back',
-              label: t('Back'),
-              action: () => {
-                fs?.goBack();
-                const pathInfo = fs?.path?.get();
-                if (pathInfo?.path) {
-                  app?.adapter.open(pathInfo.path);
-                }
-              },
-              enabled: () => fs?.canGoBack?.get() ?? false,
-            },
-          ]
-        : []),
-      {
-        id: 'open-containing-folder',
-        label: t('Open containing folder'),
-        action: () => {
-          const pathInfo = fs?.path?.get();
-
-          if (pathInfo?.breadcrumb && pathInfo.breadcrumb.length > 1) {
-            // Get parent path from breadcrumb (second to last item)
-            const parentBreadcrumb = pathInfo.breadcrumb[pathInfo.breadcrumb.length - 2];
-            const parentPath = parentBreadcrumb?.path ?? `${pathInfo.storage}://`;
-
-            app?.adapter.open(parentPath);
-          }
-        },
-        enabled: () => {
-          const pathInfo = fs?.path?.get();
-          return pathInfo?.breadcrumb && pathInfo.breadcrumb.length > 1;
-        },
-      },
-      { type: 'separator' },
-      // Dynamic storage list items will be added here
-      ...(storages.value || []).map((storage: string) => ({
-        id: `storage-${storage}`,
-        label: storage,
-        action: () => {
-          const storagePath = `${storage}://`;
-          app?.adapter.open(storagePath);
-        },
-        enabled: () => true,
-      })),
-      { type: 'separator' },
-      {
-        id: 'go-to-folder',
-        label: t('Go to Folder'),
-        action: () => app?.modal?.open(ModalGoToFolder),
-        enabled: () => true,
-      },
-    ],
-  },
-
-  {
-    id: 'help',
-    label: t('Help'),
-    items: [
-      {
-        id: 'settings',
-        label: t('Settings'),
-        action: () => app?.modal?.open(ModalSettings),
-        enabled: () => true,
-      },
-      {
-        id: 'shortcuts',
-        label: t('Shortcuts'),
-        action: () => app?.modal?.open(ModalShortcuts),
-        enabled: () => true,
-      },
-      {
-        id: 'about',
-        label: t('About'),
-        action: () => app?.modal?.open(ModalAbout),
-        enabled: () => true,
-      },
-    ],
-  },
-]);
-
 // Menu methods
-const toggleMenu = (menuId: string) => {
+const toggleMenu = (menuId?: string) => {
   if (activeMenu.value === menuId) {
     // Same menu clicked - close it
     closeMenu();
   } else {
     // Different menu clicked - open it
-    activeMenu.value = menuId;
+    activeMenu.value = menuId ?? null;
     isMenuOpen.value = true;
   }
 };
 
-const openMenu = (menuId: string) => {
+const openMenu = (menuId?: string) => {
   if (isMenuOpen.value) {
     // Menu is open, switch to hovered menu
-    activeMenu.value = menuId;
+    activeMenu.value = menuId ?? null;
   }
 };
 
@@ -533,11 +32,11 @@ const closeMenu = () => {
   isMenuOpen.value = false;
 };
 
-const handleMenuAction = (action: () => void) => {
+const handleMenuAction = (action?: () => void) => {
   // Close menu first
   closeMenu();
   // Then execute action
-  action();
+  action?.();
 };
 
 // Click outside to close menu
@@ -561,75 +60,92 @@ onUnmounted(() => {
 <template>
   <div class="vuefinder__menubar" @click.stop>
     <div class="vuefinder__menubar__container">
-      <div
-        v-for="menu in menuItems"
-        :key="menu.id"
-        class="vuefinder__menubar__item"
-        :class="{ 'vuefinder__menubar__item--active': activeMenu === menu.id }"
-        @click="toggleMenu(menu.id)"
-        @mouseenter="openMenu(menu.id)"
-      >
-        <span class="vuefinder__menubar__label">{{ menu.label }}</span>
+      <!-- Extension point: prepend custom entries (e.g. extra menus, a search box) -->
+      <slot name="menubar-start" :menu-items="menuItems" />
 
-        <!-- Dropdown menu -->
+      <!--
+        Extension point: replace the default File/Edit/View/Go/Help layout entirely.
+        Receives the same `menuItems` (and `handleMenuAction`) that power the default
+        rendering below, so a custom layout can filter/reorder them or mix in actions
+        from elsewhere (e.g. `useBreadcrumbActions`) while keeping all modal actions intact.
+      -->
+      <slot name="menu-items" :menu-items="menuItems" :handle-menu-action="handleMenuAction">
         <div
-          v-if="activeMenu === menu.id"
-          class="vuefinder__menubar__dropdown"
+          v-for="menu in menuItems"
+          :key="menu.id"
+          class="vuefinder__menubar__item"
+          :class="{ 'vuefinder__menubar__item--active': activeMenu === menu.id }"
+          @click="toggleMenu(menu.id)"
           @mouseenter="openMenu(menu.id)"
         >
+          <span class="vuefinder__menubar__label">{{ menu.label }}</span>
+
+          <!-- Dropdown menu -->
           <div
-            v-for="item in menu.items"
-            :key="item.id || item.type"
-            class="vuefinder__menubar__dropdown__item"
-            :class="{
-              'vuefinder__menubar__dropdown__item--separator': item.type === 'separator',
-              'vuefinder__menubar__dropdown__item--disabled': item.enabled && !item.enabled(),
-              'vuefinder__menubar__dropdown__item--checked': item.checked && item.checked(),
-              'vuefinder__menubar__dropdown__item--hidden': item.hidden && item.hidden(),
-              'vuefinder__menubar__dropdown__item--has-children': item.items?.length,
-            }"
-            @click.stop="
-              item.type !== 'separator' && !item.items?.length && (!item.enabled || item.enabled())
-                ? handleMenuAction(item.action)
-                : null
-            "
+            v-if="activeMenu === menu.id"
+            class="vuefinder__menubar__dropdown"
+            @mouseenter="openMenu(menu.id)"
           >
-            <span v-if="item.type !== 'separator'" class="vuefinder__menubar__dropdown__label">
-              {{ item.label }}
-            </span>
-            <span
-              v-if="item.checked && item.checked()"
-              class="vuefinder__menubar__dropdown__checkmark"
+            <div
+              v-for="item in menu.items"
+              :key="item.id || item.type"
+              class="vuefinder__menubar__dropdown__item"
+              :class="{
+                'vuefinder__menubar__dropdown__item--separator': item.type === 'separator',
+                'vuefinder__menubar__dropdown__item--disabled': item.enabled && !item.enabled(),
+                'vuefinder__menubar__dropdown__item--checked': item.checked && item.checked(),
+                'vuefinder__menubar__dropdown__item--hidden': item.hidden && item.hidden(),
+                'vuefinder__menubar__dropdown__item--has-children': item.items?.length,
+              }"
+              @click.stop="
+                item.type !== 'separator' &&
+                !item.items?.length &&
+                (!item.enabled || item.enabled())
+                  ? handleMenuAction(item.action)
+                  : null
+              "
             >
-              ✓
-            </span>
-            <svg
-              v-if="item.items?.length"
-              class="vuefinder__menubar__dropdown__chevron"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M6 4l4 4-4 4z" />
-            </svg>
-            <div v-if="item.items?.length" class="vuefinder__menubar__dropdown__submenu">
-              <div
-                v-for="child in item.items"
-                :key="child.id"
-                class="vuefinder__menubar__dropdown__item"
-                :class="{
-                  'vuefinder__menubar__dropdown__item--disabled': child.enabled && !child.enabled(),
-                }"
-                @click.stop="
-                  !child.enabled || child.enabled() ? handleMenuAction(child.action) : null
-                "
+              <span v-if="item.type !== 'separator'" class="vuefinder__menubar__dropdown__label">
+                {{ item.label }}
+              </span>
+              <span
+                v-if="item.checked && item.checked()"
+                class="vuefinder__menubar__dropdown__checkmark"
               >
-                <span class="vuefinder__menubar__dropdown__label">{{ child.label }}</span>
+                ✓
+              </span>
+              <svg
+                v-if="item.items?.length"
+                class="vuefinder__menubar__dropdown__chevron"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M6 4l4 4-4 4z" />
+              </svg>
+              <div v-if="item.items?.length" class="vuefinder__menubar__dropdown__submenu">
+                <div
+                  v-for="child in item.items"
+                  :key="child.id"
+                  class="vuefinder__menubar__dropdown__item"
+                  :class="{
+                    'vuefinder__menubar__dropdown__item--disabled':
+                      child.enabled && !child.enabled(),
+                  }"
+                  @click.stop="
+                    !child.enabled || child.enabled() ? handleMenuAction(child.action) : null
+                  "
+                >
+                  <span class="vuefinder__menubar__dropdown__label">{{ child.label }}</span>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </slot>
+
+      <!-- Extension point: append custom entries after the default menus -->
+      <slot name="menubar-end" :menu-items="menuItems" />
     </div>
   </div>
 </template>

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -212,205 +212,215 @@ const resetFilters = () => {
 </script>
 
 <template>
-  <div class="vuefinder__toolbar">
-    <div class="vuefinder__toolbar__actions">
-      <div
-        v-if="enabled('newfolder')"
-        class="mx-1.5"
-        :title="t('New Folder')"
-        @click="app.modal.open(ModalNewFolder, { items: selectedItems })"
-      >
-        <NewFolderSVG />
-      </div>
-
-      <div
-        v-if="enabled('newfile')"
-        class="mx-1.5"
-        :title="t('New File')"
-        @click="app.modal.open(ModalNewFile, { items: selectedItems })"
-      >
-        <NewFileSVG />
-      </div>
-
-      <div
-        v-if="enabled('rename')"
-        class="mx-1.5"
-        :title="t('Rename')"
-        @click="selectedItems.length !== 1 || app.modal.open(ModalRename, { items: selectedItems })"
-      >
-        <RenameSVG
-          :class="selectedItems.length === 1 ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
-        />
-      </div>
-
-      <div
-        v-if="enabled('delete')"
-        class="mx-1.5"
-        :title="t('Delete')"
-        @click="!selectedItems.length || app.modal.open(ModalDelete, { items: selectedItems })"
-      >
-        <DeleteSVG :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'" />
-      </div>
-
-      <div
-        v-if="enabled('upload')"
-        class="mx-1.5"
-        :title="t('Upload')"
-        @click="app.modal.open(ModalUpload, { items: selectedItems })"
-      >
-        <UploadSVG />
-      </div>
-
-      <div
-        v-if="
-          enabled('unarchive') &&
-          selectedItems.length === 1 &&
-          selectedItems[0].mime_type === 'application/zip'
-        "
-        class="mx-1.5"
-        :title="t('Unarchive')"
-        @click="!selectedItems.length || app.modal.open(ModalUnarchive, { items: selectedItems })"
-      >
-        <UnarchiveSVG
-          :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
-        />
-      </div>
-
-      <div
-        v-if="enabled('archive')"
-        class="mx-1.5"
-        :title="t('Archive')"
-        @click="!selectedItems.length || app.modal.open(ModalArchive, { items: selectedItems })"
-      >
-        <ArchiveSVG
-          :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
-        />
-      </div>
-    </div>
-
-    <div class="vuefinder__toolbar__controls">
-      <!-- Search Modal Button -->
-      <div
-        v-if="enabled('search')"
-        class="mx-1.5"
-        :title="t('Search Files')"
-        @click="app.modal.open(ModalSearch)"
-      >
-        <SearchSVG class="vf-toolbar-icon text-(--vf-bg-primary)" />
-      </div>
-
-      <!-- Filter dropdown -->
-      <div class="vuefinder__toolbar__control vuefinder__toolbar__dropdown-container">
+  <!-- Extension point: replace the entire toolbar with a custom component.
+       Fallback below is the default rendering; a custom component can call
+       `useMenuItems()`/`useFeature()`/`useApp()` itself to reuse the same
+       actions instead of relying on slot props. -->
+  <slot name="toolbar-items">
+    <div class="vuefinder__toolbar">
+      <div class="vuefinder__toolbar__actions">
         <div
-          :title="t('Filter')"
-          class="vuefinder__toolbar__dropdown-trigger"
-          @click="showFilterSort = !showFilterSort"
+          v-if="enabled('newfolder')"
+          class="mx-1.5"
+          :title="t('New Folder')"
+          @click="app.modal.open(ModalNewFolder, { items: selectedItems })"
         >
-          <div class="relative">
-            <FilterSVG class="vf-toolbar-icon vuefinder__toolbar__icon h-6 w-6" />
-            <!-- Filter indicator dot -->
-            <div v-if="hasActiveFilters" class="vuefinder__toolbar__filter-indicator"></div>
-          </div>
+          <NewFolderSVG />
         </div>
-        <div v-if="showFilterSort" class="vuefinder__toolbar__dropdown">
-          <div class="vuefinder__toolbar__dropdown-content">
-            <!-- Sorting -->
-            <div class="vuefinder__toolbar__dropdown-section">
-              <div class="vuefinder__toolbar__dropdown-label">{{ t('Sorting') }}</div>
-              <div class="vuefinder__toolbar__dropdown-row">
-                <select
-                  v-model="filterSortState.sortBy"
-                  class="vuefinder__toolbar__dropdown-select"
-                >
-                  <option value="name">{{ t('Name') }}</option>
-                  <option value="size">{{ t('Size') }}</option>
-                  <option value="modified">{{ t('Date') }}</option>
-                </select>
-                <select
-                  v-model="filterSortState.sortOrder"
-                  class="vuefinder__toolbar__dropdown-select"
-                >
-                  <option value="">{{ t('None') }}</option>
-                  <option value="asc">{{ t('Asc') }}</option>
-                  <option value="desc">{{ t('Desc') }}</option>
-                </select>
-              </div>
-            </div>
 
-            <!-- Filtering -->
-            <div class="vuefinder__toolbar__dropdown-section">
-              <div class="vuefinder__toolbar__dropdown-label">{{ t('Show') }}</div>
-              <div class="vuefinder__toolbar__dropdown-options">
-                <label class="vuefinder__toolbar__dropdown-option">
-                  <input
-                    v-model="filterSortState.filterKind"
-                    type="radio"
-                    name="filterKind"
-                    value="all"
-                    class="vuefinder__toolbar__radio"
-                  />
-                  <span class="vuefinder__toolbar__option-text">{{ t('All items') }}</span>
-                </label>
-                <label class="vuefinder__toolbar__dropdown-option">
-                  <input
-                    v-model="filterSortState.filterKind"
-                    type="radio"
-                    name="filterKind"
-                    value="files"
-                    class="vuefinder__toolbar__radio"
-                  />
-                  <span class="vuefinder__toolbar__option-text">{{ t('Files only') }}</span>
-                </label>
-                <label class="vuefinder__toolbar__dropdown-option">
-                  <input
-                    v-model="filterSortState.filterKind"
-                    type="radio"
-                    name="filterKind"
-                    value="folders"
-                    class="vuefinder__toolbar__radio"
-                  />
-                  <span class="vuefinder__toolbar__option-text">{{ t('Folders only') }}</span>
-                </label>
-              </div>
-            </div>
+        <div
+          v-if="enabled('newfile')"
+          class="mx-1.5"
+          :title="t('New File')"
+          @click="app.modal.open(ModalNewFile, { items: selectedItems })"
+        >
+          <NewFileSVG />
+        </div>
 
-            <!-- Hidden Files -->
-            <div class="vuefinder__toolbar__dropdown-toggle">
-              <label for="showHidden" class="vuefinder__toolbar__toggle-label">{{
-                t('Show hidden files')
-              }}</label>
-              <input
-                id="showHidden"
-                v-model="filterSortState.showHidden"
-                type="checkbox"
-                class="vuefinder__toolbar__checkbox"
-              />
-            </div>
+        <div
+          v-if="enabled('rename')"
+          class="mx-1.5"
+          :title="t('Rename')"
+          @click="
+            selectedItems.length !== 1 || app.modal.open(ModalRename, { items: selectedItems })
+          "
+        >
+          <RenameSVG
+            :class="selectedItems.length === 1 ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
+          />
+        </div>
 
-            <!-- Reset Button -->
-            <div class="vuefinder__toolbar__dropdown-reset">
-              <button class="vuefinder__toolbar__reset-button" @click="resetFilters">
-                {{ t('Reset') }}
-              </button>
-            </div>
-          </div>
+        <div
+          v-if="enabled('delete')"
+          class="mx-1.5"
+          :title="t('Delete')"
+          @click="!selectedItems.length || app.modal.open(ModalDelete, { items: selectedItems })"
+        >
+          <DeleteSVG
+            :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
+          />
+        </div>
+
+        <div
+          v-if="enabled('upload')"
+          class="mx-1.5"
+          :title="t('Upload')"
+          @click="app.modal.open(ModalUpload, { items: selectedItems })"
+        >
+          <UploadSVG />
+        </div>
+
+        <div
+          v-if="
+            enabled('unarchive') &&
+            selectedItems.length === 1 &&
+            selectedItems[0].mime_type === 'application/zip'
+          "
+          class="mx-1.5"
+          :title="t('Unarchive')"
+          @click="!selectedItems.length || app.modal.open(ModalUnarchive, { items: selectedItems })"
+        >
+          <UnarchiveSVG
+            :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
+          />
+        </div>
+
+        <div
+          v-if="enabled('archive')"
+          class="mx-1.5"
+          :title="t('Archive')"
+          @click="!selectedItems.length || app.modal.open(ModalArchive, { items: selectedItems })"
+        >
+          <ArchiveSVG
+            :class="selectedItems.length ? 'vf-toolbar-icon' : 'vf-toolbar-icon-disabled'"
+          />
         </div>
       </div>
 
-      <div
-        v-if="enabled('fullscreen')"
-        class="mx-1.5"
-        :title="t('Toggle Full Screen')"
-        @click="config.toggle('fullScreen')"
-      >
-        <MinimizeSVG v-if="configState.fullScreen" class="vf-toolbar-icon" />
-        <FullscreenSVG v-else class="vf-toolbar-icon" />
-      </div>
+      <div class="vuefinder__toolbar__controls">
+        <!-- Search Modal Button -->
+        <div
+          v-if="enabled('search')"
+          class="mx-1.5"
+          :title="t('Search Files')"
+          @click="app.modal.open(ModalSearch)"
+        >
+          <SearchSVG class="vf-toolbar-icon text-(--vf-bg-primary)" />
+        </div>
 
-      <div class="mx-1.5" :title="t('Change View')" @click="toggleView()">
-        <GridViewSVG v-if="configState.view === 'grid'" class="vf-toolbar-icon" />
-        <ListViewSVG v-if="configState.view === 'list'" class="vf-toolbar-icon" />
+        <!-- Filter dropdown -->
+        <div class="vuefinder__toolbar__control vuefinder__toolbar__dropdown-container">
+          <div
+            :title="t('Filter')"
+            class="vuefinder__toolbar__dropdown-trigger"
+            @click="showFilterSort = !showFilterSort"
+          >
+            <div class="relative">
+              <FilterSVG class="vf-toolbar-icon vuefinder__toolbar__icon h-6 w-6" />
+              <!-- Filter indicator dot -->
+              <div v-if="hasActiveFilters" class="vuefinder__toolbar__filter-indicator"></div>
+            </div>
+          </div>
+          <div v-if="showFilterSort" class="vuefinder__toolbar__dropdown">
+            <div class="vuefinder__toolbar__dropdown-content">
+              <!-- Sorting -->
+              <div class="vuefinder__toolbar__dropdown-section">
+                <div class="vuefinder__toolbar__dropdown-label">{{ t('Sorting') }}</div>
+                <div class="vuefinder__toolbar__dropdown-row">
+                  <select
+                    v-model="filterSortState.sortBy"
+                    class="vuefinder__toolbar__dropdown-select"
+                  >
+                    <option value="name">{{ t('Name') }}</option>
+                    <option value="size">{{ t('Size') }}</option>
+                    <option value="modified">{{ t('Date') }}</option>
+                  </select>
+                  <select
+                    v-model="filterSortState.sortOrder"
+                    class="vuefinder__toolbar__dropdown-select"
+                  >
+                    <option value="">{{ t('None') }}</option>
+                    <option value="asc">{{ t('Asc') }}</option>
+                    <option value="desc">{{ t('Desc') }}</option>
+                  </select>
+                </div>
+              </div>
+
+              <!-- Filtering -->
+              <div class="vuefinder__toolbar__dropdown-section">
+                <div class="vuefinder__toolbar__dropdown-label">{{ t('Show') }}</div>
+                <div class="vuefinder__toolbar__dropdown-options">
+                  <label class="vuefinder__toolbar__dropdown-option">
+                    <input
+                      v-model="filterSortState.filterKind"
+                      type="radio"
+                      name="filterKind"
+                      value="all"
+                      class="vuefinder__toolbar__radio"
+                    />
+                    <span class="vuefinder__toolbar__option-text">{{ t('All items') }}</span>
+                  </label>
+                  <label class="vuefinder__toolbar__dropdown-option">
+                    <input
+                      v-model="filterSortState.filterKind"
+                      type="radio"
+                      name="filterKind"
+                      value="files"
+                      class="vuefinder__toolbar__radio"
+                    />
+                    <span class="vuefinder__toolbar__option-text">{{ t('Files only') }}</span>
+                  </label>
+                  <label class="vuefinder__toolbar__dropdown-option">
+                    <input
+                      v-model="filterSortState.filterKind"
+                      type="radio"
+                      name="filterKind"
+                      value="folders"
+                      class="vuefinder__toolbar__radio"
+                    />
+                    <span class="vuefinder__toolbar__option-text">{{ t('Folders only') }}</span>
+                  </label>
+                </div>
+              </div>
+
+              <!-- Hidden Files -->
+              <div class="vuefinder__toolbar__dropdown-toggle">
+                <label for="showHidden" class="vuefinder__toolbar__toggle-label">{{
+                  t('Show hidden files')
+                }}</label>
+                <input
+                  id="showHidden"
+                  v-model="filterSortState.showHidden"
+                  type="checkbox"
+                  class="vuefinder__toolbar__checkbox"
+                />
+              </div>
+
+              <!-- Reset Button -->
+              <div class="vuefinder__toolbar__dropdown-reset">
+                <button class="vuefinder__toolbar__reset-button" @click="resetFilters">
+                  {{ t('Reset') }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="enabled('fullscreen')"
+          class="mx-1.5"
+          :title="t('Toggle Full Screen')"
+          @click="config.toggle('fullScreen')"
+        >
+          <MinimizeSVG v-if="configState.fullScreen" class="vf-toolbar-icon" />
+          <FullscreenSVG v-else class="vf-toolbar-icon" />
+        </div>
+
+        <div class="mx-1.5" :title="t('Change View')" @click="toggleView()">
+          <GridViewSVG v-if="configState.view === 'grid'" class="vf-toolbar-icon" />
+          <ListViewSVG v-if="configState.view === 'list'" class="vf-toolbar-icon" />
+        </div>
       </div>
     </div>
-  </div>
+  </slot>
 </template>

--- a/src/components/VueFinderProvider.vue
+++ b/src/components/VueFinderProvider.vue
@@ -78,5 +78,20 @@ onBeforeUnmount(() => {
     <template #status-bar="slotProps">
       <slot name="status-bar" v-bind="slotProps" />
     </template>
+    <template #menubar-start="slotProps">
+      <slot name="menubar-start" v-bind="slotProps" />
+    </template>
+    <template #menu-items="slotProps">
+      <slot name="menu-items" v-bind="slotProps" />
+    </template>
+    <template #menubar-end="slotProps">
+      <slot name="menubar-end" v-bind="slotProps" />
+    </template>
+    <template #toolbar-items="slotProps">
+      <slot name="toolbar-items" v-bind="slotProps" />
+    </template>
+    <template #breadcrumb-items="slotProps">
+      <slot name="breadcrumb-items" v-bind="slotProps" />
+    </template>
   </VueFinderView>
 </template>

--- a/src/components/VueFinderProvider.vue
+++ b/src/components/VueFinderProvider.vue
@@ -90,8 +90,8 @@ onBeforeUnmount(() => {
     <template #toolbar-items="slotProps">
       <slot name="toolbar-items" v-bind="slotProps" />
     </template>
-    <template #breadcrumb-items="slotProps">
-      <slot name="breadcrumb-items" v-bind="slotProps" />
+    <template #breadcrumb-actions="slotProps">
+      <slot name="breadcrumb-actions" v-bind="slotProps" />
     </template>
   </VueFinderView>
 </template>

--- a/src/components/VueFinderView.vue
+++ b/src/components/VueFinderView.vue
@@ -241,9 +241,27 @@ const handleExternalDrop = async (e: DragEvent) => {
           </div>
         </div>
 
-        <MenuBar v-if="configState.showMenuBar" />
-        <Toolbar v-if="configState.showToolbar" />
-        <Breadcrumb />
+        <MenuBar v-if="configState.showMenuBar">
+          <template #menubar-start="slotProps">
+            <slot name="menubar-start" v-bind="slotProps" />
+          </template>
+          <template #menu-items="slotProps">
+            <slot name="menu-items" v-bind="slotProps" />
+          </template>
+          <template #menubar-end="slotProps">
+            <slot name="menubar-end" v-bind="slotProps" />
+          </template>
+        </MenuBar>
+        <Toolbar v-if="configState.showToolbar">
+          <template #toolbar-items="slotProps">
+            <slot name="toolbar-items" v-bind="slotProps" />
+          </template>
+        </Toolbar>
+        <Breadcrumb v-if="configState.showBreadcrumbBar">
+          <template #breadcrumb-items="slotProps">
+            <slot name="breadcrumb-items" v-bind="slotProps" />
+          </template>
+        </Breadcrumb>
         <div class="vuefinder__main__content">
           <TreeView />
           <Explorer :on-file-dclick="props.onFileDclick" :on-folder-dclick="props.onFolderDclick">

--- a/src/components/VueFinderView.vue
+++ b/src/components/VueFinderView.vue
@@ -258,8 +258,8 @@ const handleExternalDrop = async (e: DragEvent) => {
           </template>
         </Toolbar>
         <Breadcrumb v-if="configState.showBreadcrumbBar">
-          <template #breadcrumb-items="slotProps">
-            <slot name="breadcrumb-items" v-bind="slotProps" />
+          <template #breadcrumb-actions="slotProps">
+            <slot name="breadcrumb-actions" v-bind="slotProps" />
           </template>
         </Breadcrumb>
         <div class="vuefinder__main__content">

--- a/src/composables/useBreadcrumbActions.ts
+++ b/src/composables/useBreadcrumbActions.ts
@@ -1,0 +1,61 @@
+import { useStore } from '@nanostores/vue';
+import { useApp } from './useApp';
+import { copyPath } from '../utils/clipboard';
+import { createNotifier } from '../utils/notify';
+import type { StoreValue } from 'nanostores';
+import type { CurrentPathState } from '../stores/files';
+
+/**
+ * Breadcrumb-related actions (refresh, navigate up, toggle tree view, copy
+ * path) used by `Breadcrumb.vue`.
+ *
+ * Extracted into a composable so a custom menu/tool bar can reuse the exact
+ * same behavior - e.g. to combine menu bar and breadcrumb functionality into
+ * a single bar via `MenuBar`'s slots.
+ */
+export function useBreadcrumbActions() {
+  const app = useApp();
+  const notify = createNotifier(app);
+  const fs = app.fs;
+  const config = app.config;
+  const { t } = app.i18n;
+
+  // Reactive current path/breadcrumb trail, for bars that replace `Breadcrumb.vue`
+  // entirely (via `config.showBreadcrumbBar = false`) but still want to display it.
+  const currentPath: StoreValue<CurrentPathState> = useStore(fs.path);
+
+  const refresh = () => {
+    const path = fs.path.get().path;
+    app.adapter.invalidateListQuery(path);
+    app.adapter.open(path);
+  };
+
+  const goTo = (path: string) => {
+    app.adapter.open(path);
+  };
+
+  const goUp = () => {
+    const breadcrumb = fs.path.get()?.breadcrumb ?? [];
+    const parentPath =
+      breadcrumb[breadcrumb.length - 2]?.path ?? `${fs.path.get()?.storage ?? 'local'}://`;
+    goTo(parentPath);
+  };
+
+  const toggleTreeView = () => {
+    config.toggle('showTreeView');
+  };
+
+  const copyCurrentPath = async () => {
+    await copyPath(fs.path.get()?.path || '');
+    notify.success(t('Path copied to clipboard'));
+  };
+
+  return {
+    currentPath,
+    refresh,
+    goTo,
+    goUp,
+    toggleTreeView,
+    copyCurrentPath,
+  };
+}

--- a/src/composables/useMenuItems.ts
+++ b/src/composables/useMenuItems.ts
@@ -1,0 +1,511 @@
+import { computed } from 'vue';
+import { useStore } from '@nanostores/vue';
+import { useApp } from './useApp';
+import { useFeature } from './useFeature';
+import type { DirEntry, MenuItem } from '../types';
+import { copyPath, copyDownloadUrl } from '../utils/clipboard';
+import { entryKey } from '../utils/entryKey';
+import ModalNewFolder from '../components/modals/ModalNewFolder.vue';
+import ModalNewFile from '../components/modals/ModalNewFile.vue';
+import ModalRename from '../components/modals/ModalRename.vue';
+import ModalDelete from '../components/modals/ModalDelete.vue';
+import ModalUpload from '../components/modals/ModalUpload.vue';
+import ModalUnarchive from '../components/modals/ModalUnarchive.vue';
+import ModalArchive from '../components/modals/ModalArchive.vue';
+import ModalAbout from '../components/modals/ModalAbout.vue';
+import ModalMove from '../components/modals/ModalMove.vue';
+import ModalCopy from '../components/modals/ModalCopy.vue';
+import ModalPreview from '../components/modals/ModalPreview.vue';
+import ModalSearch from '../components/modals/ModalSearch.vue';
+import ModalSettings from '../components/modals/ModalSettings.vue';
+import ModalShortcuts from '../components/modals/ModalShortcuts.vue';
+import ModalGoToFolder from '../components/modals/ModalGoToFolder.vue';
+import { format as filesizeDefault, metricFormat as filesizeMetric } from '../utils/filesize';
+import type { StoreValue } from 'nanostores';
+import type { ConfigState } from '../stores/config';
+
+/**
+ * Default menu bar structure (File/Edit/View/Go/Help) as used by `MenuBar.vue`.
+ *
+ * Extracted into a composable so the same items (and, importantly, the same
+ * modal-opening actions) can be reused to build a custom menu bar layout via
+ * `MenuBar`'s slots, without duplicating any business logic.
+ */
+export function useMenuItems() {
+  const app = useApp();
+  const { enabled } = useFeature();
+
+  const { t } = app?.i18n || { t: (key: string) => key };
+
+  const fs = app?.fs;
+  const config = app?.config;
+
+  const configState: StoreValue<ConfigState> = useStore(config.state);
+  const selectedItems: StoreValue<DirEntry[]> = useStore(fs.selectedItems);
+  const storages: StoreValue<string[]> = useStore(fs?.storages || []);
+
+  const shouldShowExit = computed(() => {
+    const canClose = window.opener !== null || window.name !== '' || window.history.length <= 1;
+    return canClose;
+  });
+
+  const menuItems = computed<MenuItem[]>(() => [
+    {
+      id: 'file',
+      label: t('File'),
+      items: [
+        {
+          id: 'new-folder',
+          label: t('New Folder'),
+          action: () => app?.modal?.open(ModalNewFolder, { items: selectedItems.value }),
+          hidden: () => !enabled('newfolder'),
+        },
+        {
+          id: 'new-file',
+          label: t('New File'),
+          action: () => app?.modal?.open(ModalNewFile, { items: selectedItems.value }),
+          hidden: () => !enabled('newfile'),
+        },
+        {
+          type: 'separator',
+          hidden: () => (!enabled('newfolder') && !enabled('newfile')) || !enabled('upload'),
+        },
+        {
+          id: 'upload',
+          label: t('Upload'),
+          action: () => app?.modal?.open(ModalUpload, { items: selectedItems.value }),
+          hidden: () => !enabled('upload'),
+        },
+        { type: 'separator', hidden: () => !enabled('search') },
+        {
+          id: 'search',
+          label: t('Search'),
+          action: () => app.modal.open(ModalSearch),
+          hidden: () => !enabled('search'),
+        },
+        { type: 'separator', hidden: () => !enabled('archive') && !enabled('unarchive') },
+        {
+          id: 'archive',
+          label: t('Archive'),
+          action: () => {
+            if (selectedItems.value.length > 0) {
+              app?.modal?.open(ModalArchive, { items: selectedItems.value });
+            }
+          },
+          enabled: () => selectedItems.value.length > 0,
+          hidden: () => !enabled('archive'),
+        },
+        {
+          id: 'unarchive',
+          label: t('Unarchive'),
+          action: () => {
+            if (
+              selectedItems.value.length === 1 &&
+              selectedItems.value[0]?.mime_type === 'application/zip'
+            ) {
+              app?.modal?.open(ModalUnarchive, { items: selectedItems.value });
+            }
+          },
+          enabled: () =>
+            selectedItems.value.length === 1 &&
+            selectedItems.value[0]?.mime_type === 'application/zip',
+          hidden: () => !enabled('unarchive'),
+        },
+        { type: 'separator', hidden: () => !enabled('preview') },
+        {
+          id: 'preview',
+          label: t('Preview'),
+          action: () => {
+            if (selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir') {
+              app?.modal?.open(ModalPreview, {
+                storage: fs?.path?.get()?.storage,
+                item: selectedItems.value[0],
+              });
+            }
+          },
+          enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
+          hidden: () => !enabled('preview'),
+        },
+        {
+          id: 'open-as',
+          label: t('Preview as'),
+          items: [
+            {
+              id: 'open-as-text',
+              label: t('Text'),
+              action: () =>
+                app?.modal?.open(ModalPreview, {
+                  storage: fs?.path?.get()?.storage,
+                  item: selectedItems.value[0],
+                  forceType: 'text',
+                }),
+              enabled: () =>
+                selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
+            },
+            {
+              id: 'open-as-image',
+              label: t('Image'),
+              action: () =>
+                app?.modal?.open(ModalPreview, {
+                  storage: fs?.path?.get()?.storage,
+                  item: selectedItems.value[0],
+                  forceType: 'image',
+                }),
+              enabled: () =>
+                selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
+            },
+          ],
+          enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
+          hidden: () => !enabled('preview'),
+        },
+        // Only show exit option if we can actually close the window
+        ...(shouldShowExit.value
+          ? [
+              { type: 'separator' as const },
+              {
+                id: 'exit',
+                label: t('Exit'),
+                action: () => {
+                  try {
+                    window.close();
+                  } catch {
+                    // Window cannot be closed programmatically
+                  }
+                },
+                enabled: () => true,
+              },
+            ]
+          : []),
+      ],
+    },
+    {
+      id: 'edit',
+      label: t('Edit'),
+      items: [
+        // Only show Select All and Deselect All in multiple selection mode
+        ...(app?.selectionMode === 'multiple'
+          ? [
+              {
+                id: 'select-all',
+                label: t('Select All'),
+                action: () =>
+                  fs?.selectAll((app?.selectionMode as 'single' | 'multiple') || 'multiple', app),
+                enabled: () => true,
+              },
+              {
+                id: 'deselect',
+                label: t('Deselect All'),
+                action: () => fs?.clearSelection(),
+                enabled: () => selectedItems.value.length > 0,
+              },
+              { type: 'separator' as const },
+            ]
+          : []),
+        ...(enabled('copy')
+          ? [
+              {
+                id: 'cut',
+                label: t('Cut'),
+                action: () => {
+                  if (selectedItems.value.length > 0) {
+                    fs?.setClipboard(
+                      'cut',
+                      new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
+                    );
+                  }
+                },
+                enabled: () => selectedItems.value.length > 0,
+              },
+              {
+                id: 'copy',
+                label: t('Copy'),
+                action: () => {
+                  if (selectedItems.value.length > 0) {
+                    fs?.setClipboard(
+                      'copy',
+                      new Set(selectedItems.value.map((item: DirEntry) => entryKey(item)))
+                    );
+                  }
+                },
+                enabled: () => selectedItems.value.length > 0,
+              },
+              {
+                id: 'paste',
+                label: t('Paste'),
+                action: () => {
+                  const clipboard = fs?.getClipboard();
+                  if (clipboard?.items?.size > 0) {
+                    app?.modal?.open(clipboard.type === 'cut' ? ModalMove : ModalCopy, {
+                      items: { from: Array.from(clipboard.items), to: fs?.path?.get() },
+                    });
+                  }
+                },
+                enabled: () => {
+                  const clipboard = fs?.getClipboard();
+                  return clipboard?.items?.size > 0;
+                },
+              },
+            ]
+          : []),
+        ...(enabled('move')
+          ? [
+              {
+                id: 'move',
+                label: t('Move files'),
+                action: () => {
+                  if (selectedItems.value.length > 0) {
+                    const target = {
+                      storage: fs?.path?.get()?.storage || '',
+                      path: fs?.path?.get()?.path || '',
+                      type: 'dir' as const,
+                    };
+                    app?.modal?.open(ModalMove, {
+                      items: { from: selectedItems.value, to: target },
+                    });
+                  }
+                },
+                enabled: () => selectedItems.value.length > 0,
+              },
+              { type: 'separator' as const },
+            ]
+          : []),
+        {
+          id: 'copy-path',
+          label: t('Copy Path'),
+          action: async () => {
+            if (selectedItems.value.length === 1) {
+              // Copy selected item's path
+              const item = selectedItems.value[0];
+              await copyPath(item.path);
+            } else {
+              // Copy current path if no item selected
+              const currentPath = fs?.path?.get();
+              if (currentPath?.path) {
+                await copyPath(currentPath.path);
+              }
+            }
+          },
+          enabled: () => true,
+        },
+        {
+          id: 'copy-download-url',
+          label: t('Copy Download URL'),
+          action: async () => {
+            if (selectedItems.value.length === 1) {
+              const item = selectedItems.value[0];
+              const downloadUrl = app?.adapter?.getDownloadUrl({ path: item.path });
+              if (downloadUrl) {
+                await copyDownloadUrl(downloadUrl);
+              }
+            }
+          },
+          enabled: () => selectedItems.value.length === 1 && selectedItems.value[0]?.type !== 'dir',
+        },
+        { type: 'separator', hidden: () => !enabled('rename') && !enabled('delete') },
+        {
+          id: 'rename',
+          label: t('Rename'),
+          action: () => {
+            if (selectedItems.value.length === 1) {
+              app?.modal?.open(ModalRename, { items: selectedItems.value });
+            }
+          },
+          enabled: () => selectedItems.value.length === 1,
+          hidden: () => !enabled('rename'),
+        },
+        {
+          id: 'delete',
+          label: t('Delete'),
+          action: () => {
+            if (selectedItems.value.length > 0) {
+              app?.modal?.open(ModalDelete, { items: selectedItems.value });
+            }
+          },
+          enabled: () => selectedItems.value.length > 0,
+          hidden: () => !enabled('delete'),
+        },
+      ],
+    },
+    {
+      id: 'view',
+      label: t('View'),
+      items: [
+        {
+          id: 'refresh',
+          label: t('Refresh'),
+          action: () => {
+            app.adapter.invalidateListQuery(fs.path.get().path);
+            app.adapter.open(fs.path.get().path);
+          },
+          enabled: () => true,
+        },
+        { type: 'separator' },
+        {
+          id: 'grid-view',
+          label: t('Grid View'),
+          action: () => config?.set('view', 'grid'),
+          enabled: () => true,
+          checked: () => configState.value?.view === 'grid',
+        },
+        {
+          id: 'list-view',
+          label: t('List View'),
+          action: () => config?.set('view', 'list'),
+          enabled: () => true,
+          checked: () => configState.value?.view === 'list',
+        },
+        { type: 'separator' },
+        {
+          id: 'tree-view',
+          label: t('Tree View'),
+          action: () => config?.toggle('showTreeView'),
+          enabled: () => true,
+          checked: () => configState.value?.showTreeView,
+        },
+        {
+          id: 'thumbnails',
+          label: t('Show Thumbnails'),
+          action: () => config?.toggle('showThumbnails'),
+          enabled: () => true,
+          checked: () => configState.value?.showThumbnails,
+        },
+        {
+          id: 'show-hidden-files',
+          label: t('Show Hidden Files'),
+          action: () => config?.toggle('showHiddenFiles'),
+          enabled: () => true,
+          checked: () => configState.value?.showHiddenFiles,
+        },
+        { type: 'separator', hidden: () => !enabled('fullscreen') },
+        {
+          id: 'fullscreen',
+          label: t('Full Screen'),
+          action: () => config?.toggle('fullScreen'),
+          enabled: () => enabled('fullscreen'),
+          checked: () => configState.value?.fullScreen,
+          hidden: () => !enabled('fullscreen'),
+        },
+        { type: 'separator' },
+        {
+          id: 'persist-path',
+          label: t('Persist Path'),
+          action: () => {
+            config?.toggle('persist');
+            app.emitter.emit('vf-persist-path-saved');
+          },
+          enabled: () => true,
+          checked: () => configState.value?.persist,
+        },
+        {
+          id: 'metric-units',
+          label: t('Metric Units'),
+          action: () => {
+            config?.toggle('metricUnits');
+            app.filesize = config?.get('metricUnits') ? filesizeMetric : filesizeDefault;
+            app.emitter.emit('vf-metric-units-saved');
+          },
+          enabled: () => true,
+          checked: () => configState.value?.metricUnits,
+        },
+      ],
+    },
+    {
+      id: 'go',
+      label: t('Go'),
+      items: [
+        ...(enabled('history')
+          ? [
+              {
+                id: 'forward',
+                label: t('Forward'),
+                action: () => {
+                  fs?.goForward();
+                  const pathInfo = fs?.path?.get();
+                  if (pathInfo?.path) {
+                    app?.adapter.open(pathInfo.path);
+                  }
+                },
+                enabled: () => fs?.canGoForward?.get() ?? false,
+              },
+              {
+                id: 'back',
+                label: t('Back'),
+                action: () => {
+                  fs?.goBack();
+                  const pathInfo = fs?.path?.get();
+                  if (pathInfo?.path) {
+                    app?.adapter.open(pathInfo.path);
+                  }
+                },
+                enabled: () => fs?.canGoBack?.get() ?? false,
+              },
+            ]
+          : []),
+        {
+          id: 'open-containing-folder',
+          label: t('Open containing folder'),
+          action: () => {
+            const pathInfo = fs?.path?.get();
+
+            if (pathInfo?.breadcrumb && pathInfo.breadcrumb.length > 1) {
+              // Get parent path from breadcrumb (second to last item)
+              const parentBreadcrumb = pathInfo.breadcrumb[pathInfo.breadcrumb.length - 2];
+              const parentPath = parentBreadcrumb?.path ?? `${pathInfo.storage}://`;
+
+              app?.adapter.open(parentPath);
+            }
+          },
+          enabled: () => {
+            const pathInfo = fs?.path?.get();
+            return pathInfo?.breadcrumb && pathInfo.breadcrumb.length > 1;
+          },
+        },
+        { type: 'separator' },
+        // Dynamic storage list items will be added here
+        ...(storages.value || []).map((storage: string) => ({
+          id: `storage-${storage}`,
+          label: storage,
+          action: () => {
+            const storagePath = `${storage}://`;
+            app?.adapter.open(storagePath);
+          },
+          enabled: () => true,
+        })),
+        { type: 'separator' },
+        {
+          id: 'go-to-folder',
+          label: t('Go to Folder'),
+          action: () => app?.modal?.open(ModalGoToFolder),
+          enabled: () => true,
+        },
+      ],
+    },
+
+    {
+      id: 'help',
+      label: t('Help'),
+      items: [
+        {
+          id: 'settings',
+          label: t('Settings'),
+          action: () => app?.modal?.open(ModalSettings),
+          enabled: () => true,
+        },
+        {
+          id: 'shortcuts',
+          label: t('Shortcuts'),
+          action: () => app?.modal?.open(ModalShortcuts),
+          enabled: () => true,
+        },
+        {
+          id: 'about',
+          label: t('About'),
+          action: () => app?.modal?.open(ModalAbout),
+          enabled: () => true,
+        },
+      ],
+    },
+  ]);
+
+  return { menuItems, shouldShowExit };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import {
   parseBackendError,
 } from './adapters';
 import { useVueFinder } from './composables/useVueFinder';
+import { useMenuItems } from './composables/useMenuItems';
+import { useBreadcrumbActions } from './composables/useBreadcrumbActions';
 
 type VueFinderOptions = {
   i18n?: Record<string, unknown>;
@@ -35,7 +37,7 @@ export const VueFinderPlugin = {
 export default VueFinderPlugin;
 
 export { VueFinder, VueFinderProvider, contextMenuItems, ContextMenuIds };
-export { useVueFinder };
+export { useVueFinder, useMenuItems, useBreadcrumbActions };
 
 export { RemoteDriver, ArrayDriver, IndexedDBDriver, BaseAdapter, parseBackendError };
 
@@ -50,6 +52,7 @@ export type {
   NotifyEvent,
   NotifyPayload,
   VueFinderComposable,
+  MenuItem,
 } from './types';
 
 // Export context menu item type

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -36,6 +36,7 @@ export interface NonPersistenceConfigState {
   maxFileSize: number | string | null;
   showMenuBar: boolean;
   showToolbar: boolean;
+  showBreadcrumbBar: boolean;
   gridItemWidth: number;
   gridItemHeight: number;
   gridItemGap: number;
@@ -102,6 +103,7 @@ const DEFAULT_NON_PERSISTENCE_STATE: NonPersistenceConfigState = {
   loadingIndicator: 'circular',
   showMenuBar: true,
   showToolbar: true,
+  showBreadcrumbBar: true,
   gridItemWidth: 96,
   gridItemHeight: 80,
   gridItemGap: 8,

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,5 +142,16 @@ export interface FsData {
   read_only?: boolean;
 }
 
+export interface MenuItem {
+  id?: string;
+  label?: string;
+  type?: 'separator';
+  items?: MenuItem[];
+  action?: () => void;
+  enabled?: () => boolean;
+  hidden?: () => boolean;
+  checked?: () => boolean;
+}
+
 // Re-export feature types for convenience
 export type { FeatureName, FeaturesConfig, FeaturesPreset } from './features';


### PR DESCRIPTION
## Summary

- Add the possibility to use slots to replace the UI elements: `MenuBar`, `Breadcrumb` and `Toolbar`
- The slot for the Breadcrumb does not replace the complete Breadcrumb bar, but only the buttons before the breadcrumb path container (tree-view toggle, go up, refresh) — the path container itself is too complex to reasonably reimplement, so it's not slotted
- There is a possibility to replace the complete `MenuBar` with a slot, but also to add content before or after the original menu
- To reuse the built-in functionality in a custom component, there are now two composables: `useMenuItems` and `useBreadcrumbActions`
- Add the possibility to hide the Breadcrumb bar with `showBreadcrumbBar` (consistent with the existing `showMenuBar`/`showToolbar`)
- Added the use cases to the examples
- Added new tests for the slots and the two extra composables
- Updated the documentation

## Screenshot

[](url)
<img width="1246" height="573" alt="Screenshot from 2026-07-14 13-14-32" src="https://github.com/user-attachments/assets/93705a06-cf68-4a16-bc3e-fc9b3eb6496c" />

<img width="1246" height="573" alt="grafik" src="https://github.com/user-attachments/assets/9113c2f8-6b0b-4b69-95da-ae5e93020a92" />

## Test

### Regression 

- [ ] MenuBar dropdowns and Actions work exactly as before
- [ ] Toolbar Actions work exactly as before
- [ ] Breadcrumb Actions work exaclty as before 

### MenuBar Customization

- [ ]  menubar-start/menubar-end slots: custom elements are shown before/after the menus, default menus still work
- [ ]  menu-items slot: add your own elements and wire up functionality with useMenuItems

### Toolbar Customization

- [ ] toolbar-items slot: add your own elements and wire up functionality with useMenuItems, useFeature, useApp depending on what's needed

### Breadcrumb Customization
- [ ] add `showBreadcrumbBar` to the config to check that the Breadcrumb is visible when `true` and hidden when `false`
- [ ] breadcrumb-actions slot: add your own action buttons and wire up functionality with `useBreadcrumbActions` — verify the path container (segments, hidden-dropdown, path-copy mode) still renders and works normally next to the custom buttons
- [ ] check if breadcrumb-actions slot is active, path navigation (click segment, go up) still works.

Made in cooperation with Claude. 
