### PR TITLE
fix: notificationsEnabled now respects prop over persisted value (#194)

### DIFF
--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -21,7 +21,6 @@ export interface PersistenceConfigState {
   persist: boolean;
   path: string;
   pinnedFolders: DirEntry[];
-  notificationsEnabled: boolean;
   expandTreeByDefault: boolean;
   expandedTreePaths: string[];
 }
@@ -50,6 +49,7 @@ export interface NonPersistenceConfigState {
     | 'bottom-left'
     | 'bottom-center'
     | 'bottom-right';
+  notificationsEnabled: boolean;
   notificationDuration: number;
   notificationVisibleToasts: number;
   notificationRichColors: boolean;
@@ -91,7 +91,6 @@ const DEFAULT_PERSISTENCE_STATE: PersistenceConfigState = {
   persist: false,
   path: '',
   pinnedFolders: [] as DirEntry[],
-  notificationsEnabled: true,
   expandTreeByDefault: false,
   expandedTreePaths: [] as string[],
 };
@@ -109,6 +108,7 @@ const DEFAULT_NON_PERSISTENCE_STATE: NonPersistenceConfigState = {
   listItemHeight: 32,
   listItemGap: 2,
   listIconSize: 16,
+  notificationsEnabled: true,
   notificationPosition: 'bottom-center',
   notificationDuration: 3000,
   notificationVisibleToasts: 4,


### PR DESCRIPTION
Fixes #194.

`notificationsEnabled` was stored in the persistent config group, so once it was cached in `localStorage` (`vuefinder_config_*`) it took precedence over the prop — meaning `notificationsEnabled: false` had no effect on later page loads.

Moved it to the non-persistent config group, consistent with the other notification options (`notificationPosition`, `notificationDuration`, `notificationRichColors`, `notificationVisibleToasts`), which were all already runtime-only. Now the prop value always takes effect.

The `@notify` event is unaffected and still fires regardless, so custom notification handling keeps working.