### PR TITLE
fix: use dirname for image editor save target at storage root (#202)

### DIFF
--- a/src/__tests__/path.spec.ts
+++ b/src/__tests__/path.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, splitPath } from '../utils/path';
+
+describe('splitPath', () => {
+  it('splits a full path into storage and path', () => {
+    expect(splitPath('local://A/B')).toEqual(['local', '/A/B']);
+  });
+
+  it('returns a root path for a bare storage', () => {
+    expect(splitPath('local://')).toEqual(['local', '/']);
+  });
+
+  it('returns no storage when the prefix is missing', () => {
+    expect(splitPath('A/B')).toEqual([undefined, 'A/B']);
+  });
+});
+
+describe('dirname', () => {
+  it('keeps the double slash for files at the storage root', () => {
+    expect(dirname('local://photo.jpg')).toBe('local://');
+  });
+
+  it('returns the storage root for the storage root itself', () => {
+    expect(dirname('local://')).toBe('local://');
+  });
+
+  it('returns the parent folder for nested paths', () => {
+    expect(dirname('local://A/B')).toBe('local://A');
+    expect(dirname('local://A/B/photo.jpg')).toBe('local://A/B');
+  });
+
+  it('ignores trailing slashes', () => {
+    expect(dirname('local://A/B/')).toBe('local://A');
+  });
+
+  it('returns undefined when there is no storage prefix', () => {
+    expect(dirname('photo.jpg')).toBeUndefined();
+    expect(dirname('A/B/photo.jpg')).toBeUndefined();
+  });
+
+  it('recovers from a single-slash storage separator', () => {
+    expect(dirname('local:/photo.jpg')).toBe('local://');
+    expect(dirname('local:/A/photo.jpg')).toBe('local://A');
+  });
+});

--- a/src/components/previews/Image.vue
+++ b/src/components/previews/Image.vue
@@ -7,6 +7,7 @@ import useUpload, { QUEUE_ENTRY_STATUS } from '../../composables/useUpload';
 import { getErrorMessage } from '../../utils/errorHandler';
 import { createNotifier } from '../../utils/notify';
 import { dataUrlToBlob } from '../../utils/imageEditor';
+import { dirname } from '../../utils/path';
 import LazyLoad from 'vanilla-lazyload';
 import { useStore } from '@nanostores/vue';
 import ImageEditor from './ImageEditor.vue';
@@ -242,9 +243,9 @@ const save = async () => {
     const file = new File([blob], originalFilename, { type: mimeType });
 
     const fullPath = app.modal.data.item.path;
-    const pathParts = fullPath.split('/');
-    pathParts.pop();
-    const directoryPath = pathParts.join('/');
+    // dirname keeps the `storage://` prefix intact for files sitting directly
+    // at the storage root — a naive split/pop/join would yield `storage:/`.
+    const directoryPath = dirname(fullPath);
 
     const targetFolder = {
       path: directoryPath || (currentPath.value?.path ?? ''),

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,10 +1,23 @@
+/**
+ * Retrieve the parent directory of a full `storage://path` string.
+ * Returns undefined when the input carries no storage prefix, so callers
+ * can fall back to the current path instead of building a bogus target.
+ *
+ * @example
+ * dirname('local://') -> 'local://'
+ * dirname('local://A') -> 'local://'
+ * dirname('local://A/B') -> 'local://A'
+ * dirname('A/B') -> undefined
+ */
 export function dirname(fullPath: string): string | undefined {
   const [storage, path] = splitPath(fullPath);
-  if (!path || path === '/') return storage + '://';
-  const trimmed = path.replace(/\/+$/, '');
+  if (storage === undefined) return undefined;
+  // Strip leading/trailing slashes so the root case collapses to '' and the
+  // storage prefix is always re-attached with its full '://' separator.
+  const trimmed = path.replace(/^\/+/, '').replace(/\/+$/, '');
   const index = trimmed.lastIndexOf('/');
-  if (index === 0) return storage + '://';
-  return storage + ':/' + trimmed.slice(0, index);
+  if (index === -1) return storage + '://';
+  return storage + '://' + trimmed.slice(0, index);
 }
 
 export function splitPath(fullPath: string): [string | undefined, string] {


### PR DESCRIPTION
Saving an edited image at the storage root built the target folder with split/pop/join, producing `storage:/` instead of `storage://`. Subfolders were unaffected.

Wires the existing unused `dirname` helper into the image preview save path and hardens it: strips leading slashes, returns `undefined` without a storage prefix so the `currentPath` fallback works, recovers from a single-slash separator. Adds unit tests for `dirname` and `splitPath`.

Closes #202