### PR TITLE
Folder upload structure fix, MenuBar slot demos

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -281,6 +281,7 @@ gtag('config', 'G-6BYQESCJ6R');`
             { text: 'Item Size Configuration', link: '/examples/item-size-configuration' },
             { text: 'Feature Presets', link: '/examples/feature-presets' },
             { text: 'UI Visibility', link: '/examples/ui-visibility' },
+            { text: 'Custom Menu Bar', link: '/examples/custom-menu-bar' },
             { text: 'Single Selection', link: '/examples/single-selection' },
             { text: 'Selection Filters', link: '/examples/selection-filters' },
             { text: 'Custom Double-Click', link: '/examples/custom-double-click' },

--- a/docs/.vitepress/theme/components/examples/CustomMenuBarBar.vue
+++ b/docs/.vitepress/theme/components/examples/CustomMenuBarBar.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+// Rendered through `#menu-items`. It picks a handful of actions out of the
+// default menus by id and pairs them with the breadcrumb actions, so a single
+// row covers what the menu bar, toolbar and breadcrumb bar do by default.
+import { computed } from 'vue';
+import { useMenuItems, useBreadcrumbActions } from 'vuefinder';
+import type { MenuItem } from 'vuefinder';
+
+const { menuItems } = useMenuItems();
+// Destructured so `currentPath` stays a top-level binding and the template
+// unwraps it; `breadcrumb.currentPath.path` would read through the ref object.
+const { currentPath, goUp, refresh } = useBreadcrumbActions();
+
+const byId = computed(() => {
+  const map = new Map<string, MenuItem>();
+  for (const menu of menuItems.value) {
+    for (const item of menu.items ?? []) {
+      if (item.id) map.set(item.id, item);
+    }
+  }
+  return map;
+});
+
+const pick = (ids: string[]) =>
+  ids
+    .map((id) => byId.value.get(id))
+    .filter((item): item is MenuItem => Boolean(item) && !item?.hidden?.());
+
+const primary = computed(() => pick(['new-folder', 'upload', 'rename', 'delete']));
+const views = computed(() => pick(['grid-view', 'list-view']));
+
+const isDisabled = (item: MenuItem) => (item.enabled ? !item.enabled() : false);
+
+const run = (item: MenuItem) => {
+  if (isDisabled(item)) return;
+  item.action?.();
+};
+</script>
+
+<template>
+  <div class="cmb">
+    <div class="cmb__actions">
+      <button
+        v-for="item in primary"
+        :key="item.id"
+        class="cmb__btn"
+        :disabled="isDisabled(item)"
+        @click="run(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <div class="cmb__path" :title="currentPath.path">
+      <button class="cmb__icon" title="Go up" @click="goUp()">↑</button>
+      <button class="cmb__icon" title="Refresh" @click="refresh()">⟳</button>
+      <span class="cmb__path-text">{{ currentPath.path }}</span>
+    </div>
+
+    <div class="cmb__actions">
+      <button
+        v-for="item in views"
+        :key="item.id"
+        class="cmb__btn"
+        :class="{ 'cmb__btn--on': item.checked?.() }"
+        @click="run(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cmb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  padding: 5px 8px;
+}
+
+.cmb__actions {
+  display: flex;
+  flex: none;
+  gap: 3px;
+  align-items: center;
+}
+
+.cmb__path {
+  display: flex;
+  flex: 1 1 12rem;
+  gap: 3px;
+  align-items: center;
+  min-width: 0;
+}
+
+.cmb__path-text {
+  overflow: hidden;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.7rem;
+  color: var(--vp-c-text-3);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cmb__btn,
+.cmb__icon {
+  padding: 1px 6px;
+  font-size: 0.7rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-1);
+  white-space: nowrap;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.cmb__icon {
+  padding: 1px 5px;
+}
+
+.cmb__btn:hover:not(:disabled),
+.cmb__icon:hover {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.cmb__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cmb__btn--on {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/examples/CustomMenuBarDemo.vue
+++ b/docs/.vitepress/theme/components/examples/CustomMenuBarDemo.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+// A practical use of the MenuBar slots: replace the menu bar with a single
+// compact toolbar and hide the default toolbar and breadcrumb bar, so an
+// embedded file manager costs one row of chrome instead of three.
+import { computed, ref, onMounted } from 'vue';
+import type { Driver } from 'vuefinder';
+import CustomMenuBarBar from './CustomMenuBarBar.vue';
+
+const compact = ref(true);
+
+const config = computed(() => ({
+  initialPath: 'local://',
+  persist: false,
+  // The slot replaces what is *inside* the menu bar; these remove the other
+  // two bars entirely.
+  showToolbar: !compact.value,
+  showBreadcrumbBar: !compact.value,
+}));
+
+const driver = ref<Driver | null>(null);
+
+onMounted(async () => {
+  const { RemoteDriver } = await import('vuefinder');
+  driver.value = new RemoteDriver({
+    baseURL: 'https://vuefinder-api.ozdemir.be/api/files',
+  });
+});
+</script>
+
+<template>
+  <div class="cmb-demo">
+    <div class="cmb-demo__bar">
+      <span class="cmb-demo__hint">
+        One custom bar replaces three default ones — the actions are the real
+        ones, driven by <code>useMenuItems()</code>.
+      </span>
+      <label class="cmb-demo__switch">
+        <input v-model="compact" type="checkbox" />
+        Compact layout
+      </label>
+    </div>
+
+    <div class="cmb-demo__viewer">
+      <ClientOnly>
+        <vue-finder v-if="driver" id="demo-custom-menu-bar" :driver="driver" :config="config">
+          <template #menu-items>
+            <CustomMenuBarBar />
+          </template>
+        </vue-finder>
+        <template #fallback>
+          <div class="cmb-demo__loading">Loading demo...</div>
+        </template>
+      </ClientOnly>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cmb-demo {
+  overflow: hidden;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+}
+
+.cmb-demo__bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--vp-c-bg-soft);
+  border-bottom: 1px solid var(--vp-c-border);
+}
+
+.cmb-demo__hint {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+
+.cmb-demo__hint code {
+  font-size: 0.75rem;
+}
+
+.cmb-demo__switch {
+  display: flex;
+  flex: none;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+}
+
+/* Definite height: VueFinder sizes itself with height:100%, which only
+   resolves against a parent whose own height is definite. */
+.cmb-demo__viewer {
+  height: 420px;
+}
+
+.cmb-demo__loading {
+  padding: 2rem;
+  color: var(--vp-c-text-2);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .cmb-demo__viewer {
+    height: 340px;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/examples/MenuBarSlotsCombinedBar.vue
+++ b/docs/.vitepress/theme/components/examples/MenuBarSlotsCombinedBar.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+// Rendered through MenuBar's `#menu-items` slot. Because it lives inside the
+// VueFinder instance, `useMenuItems()` / `useBreadcrumbActions()` resolve
+// against that instance exactly as they do in the library's own components -
+// so this bar can drive the real actions (modals included) rather than
+// reimplementing them.
+import { computed } from 'vue';
+import { useMenuItems, useBreadcrumbActions } from 'vuefinder';
+import type { MenuItem } from 'vuefinder';
+
+const { menuItems } = useMenuItems();
+// Destructured so `currentPath` stays a top-level binding and the template
+// unwraps it; `breadcrumb.currentPath.path` would read through the ref object.
+const { currentPath, goUp, refresh, toggleTreeView, copyCurrentPath } = useBreadcrumbActions();
+
+const actionsOf = (id: string, only?: string[]): MenuItem[] => {
+  const menu = menuItems.value.find((m) => m.id === id);
+  const items = (menu?.items ?? []).filter(
+    (item) => item.type !== 'separator' && !item.items?.length && !item.hidden?.()
+  );
+  return only ? items.filter((item) => only.includes(item.id ?? '')) : items;
+};
+
+const groups = computed(() => [
+  { label: 'File', items: actionsOf('file') },
+  { label: 'Edit', items: actionsOf('edit') },
+  // The same view actions the default Toolbar exposes, so hiding the toolbar
+  // does not lose them.
+  { label: 'View', items: actionsOf('view', ['grid-view', 'list-view', 'fullscreen']) },
+]);
+
+const isDisabled = (item: MenuItem) => (item.enabled ? !item.enabled() : false);
+
+const run = (item: MenuItem) => {
+  if (isDisabled(item)) return;
+  item.action?.();
+};
+</script>
+
+<template>
+  <div class="vf-combined-bar">
+    <div class="vf-combined-bar__path" :title="currentPath.path">
+      {{ currentPath.path }}
+    </div>
+
+    <div class="vf-combined-bar__groups">
+      <div v-for="group in groups" :key="group.label" class="vf-combined-bar__group">
+        <span class="vf-combined-bar__label">{{ group.label }}</span>
+        <button
+          v-for="item in group.items"
+          :key="item.id"
+          class="vf-combined-bar__btn"
+          :class="{ 'vf-combined-bar__btn--on': item.checked?.() }"
+          :disabled="isDisabled(item)"
+          @click="run(item)"
+        >
+          {{ item.label }}
+        </button>
+      </div>
+
+      <div class="vf-combined-bar__group">
+        <span class="vf-combined-bar__label">Breadcrumb</span>
+        <button class="vf-combined-bar__btn" @click="refresh()">Refresh</button>
+        <button class="vf-combined-bar__btn" @click="goUp()">Go Up</button>
+        <button class="vf-combined-bar__btn" @click="toggleTreeView()">Tree</button>
+        <button class="vf-combined-bar__btn" @click="copyCurrentPath()">Copy Path</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.vf-combined-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  padding: 5px 8px;
+}
+
+.vf-combined-bar__path {
+  overflow: hidden;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.7rem;
+  color: var(--vp-c-text-3);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vf-combined-bar__groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 10px;
+  align-items: center;
+}
+
+.vf-combined-bar__group {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.vf-combined-bar__label {
+  margin-right: 2px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--vp-c-text-3);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.vf-combined-bar__btn {
+  padding: 1px 5px;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-1);
+  white-space: nowrap;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.vf-combined-bar__btn:hover:not(:disabled) {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.vf-combined-bar__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.vf-combined-bar__btn--on {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/examples/MenuBarSlotsDemo.vue
+++ b/docs/.vitepress/theme/components/examples/MenuBarSlotsDemo.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue';
+import type { Driver } from 'vuefinder';
+import MenuBarSlotsCombinedBar from './MenuBarSlotsCombinedBar.vue';
+
+type Mode = 'default' | 'around' | 'replace' | 'each';
+
+const modes: { id: Mode; tab: string; title: string; description: string }[] = [
+  {
+    id: 'default',
+    tab: 'No slots',
+    title: 'Default menu bar',
+    description:
+      'The starting point: File / Edit / View / Go / Help rendered by VueFinder, with no slot passed.',
+  },
+  {
+    id: 'around',
+    tab: 'Add around',
+    title: 'menubar-start / menubar-end',
+    description:
+      'Keep the default menus and add your own content before and after them — branding, a shortcut, a counter. menubar-end receives the resolved menuItems.',
+  },
+  {
+    id: 'replace',
+    tab: 'Replace layout',
+    title: 'menu-items',
+    description:
+      'Replace the menu layout entirely. The custom bar calls useMenuItems() and useBreadcrumbActions() itself rather than relying on the scoped props, so it drives the real actions — modals included.',
+  },
+  {
+    id: 'each',
+    tab: 'Each bar',
+    title: 'menu-items + toolbar-items + breadcrumb-actions',
+    description:
+      'Every bar replaced independently through its own slot. The slot content replaces what is inside a bar — to remove a bar altogether, use the visibility options instead.',
+  },
+];
+
+const mode = ref<Mode>('default');
+const active = computed(() => modes.find((m) => m.id === mode.value)!);
+
+const config = {
+  initialPath: 'local://',
+  persist: false,
+};
+
+const driver = ref<Driver | null>(null);
+
+onMounted(async () => {
+  const { RemoteDriver } = await import('vuefinder');
+  driver.value = new RemoteDriver({
+    baseURL: 'https://vuefinder-api.ozdemir.be/api/files',
+  });
+});
+</script>
+
+<template>
+  <div class="slots-demo">
+    <div class="slots-demo__tabs" role="tablist">
+      <button
+        v-for="item in modes"
+        :key="item.id"
+        class="slots-demo__tab"
+        :class="{ 'slots-demo__tab--active': mode === item.id }"
+        role="tab"
+        :aria-selected="mode === item.id"
+        @click="mode = item.id"
+      >
+        {{ item.tab }}
+      </button>
+    </div>
+
+    <div class="slots-demo__intro">
+      <h4 class="slots-demo__title">{{ active.title }}</h4>
+      <p class="slots-demo__description">{{ active.description }}</p>
+    </div>
+
+    <div class="slots-demo__viewer">
+      <ClientOnly>
+        <vue-finder v-if="driver && mode === 'default'" id="demo-slots-default" :driver="driver" :config="config" />
+
+        <vue-finder v-else-if="driver && mode === 'around'" id="demo-slots-around" :driver="driver" :config="config">
+          <template #menubar-start>
+            <span class="slots-demo__chip">🗂️ My App</span>
+          </template>
+          <template #menubar-end="{ menuItems }">
+            <span class="slots-demo__chip">{{ menuItems.length }} menus</span>
+          </template>
+        </vue-finder>
+
+        <vue-finder v-else-if="driver && mode === 'replace'" id="demo-slots-replace" :driver="driver" :config="config">
+          <template #menu-items>
+            <MenuBarSlotsCombinedBar />
+          </template>
+        </vue-finder>
+
+        <vue-finder v-else-if="driver" id="demo-slots-each" :driver="driver" :config="config">
+          <template #menu-items="{ menuItems }">
+            <div class="slots-demo__chip slots-demo__chip--block">
+              Custom MenuBar ({{ menuItems.length }} menus)
+            </div>
+          </template>
+          <template #toolbar-items>
+            <div class="slots-demo__chip slots-demo__chip--block">Custom Toolbar</div>
+          </template>
+          <template #breadcrumb-actions>
+            <div class="slots-demo__chip">Custom Breadcrumb Actions</div>
+          </template>
+        </vue-finder>
+
+        <template #fallback>
+          <div class="slots-demo__loading">Loading demo...</div>
+        </template>
+      </ClientOnly>
+    </div>
+
+    <!-- The snippets come in as slots so VitePress renders them through Shiki,
+         matching the site's own code blocks in both light and dark themes. -->
+    <div class="slots-demo__code">
+      <div v-show="mode === 'default'"><slot name="code-default" /></div>
+      <div v-show="mode === 'around'"><slot name="code-around" /></div>
+      <div v-show="mode === 'replace'"><slot name="code-replace" /></div>
+      <div v-show="mode === 'each'"><slot name="code-each" /></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.slots-demo {
+  overflow: hidden;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+}
+
+.slots-demo__tabs {
+  display: flex;
+  overflow-x: auto;
+  background: var(--vp-c-bg-soft);
+  border-bottom: 1px solid var(--vp-c-border);
+}
+
+.slots-demo__tab {
+  padding: 0.6rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.slots-demo__tab:hover {
+  color: var(--vp-c-text-1);
+}
+
+.slots-demo__tab--active {
+  color: var(--vp-c-brand-1);
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+.slots-demo__intro {
+  padding: 1rem;
+  border-bottom: 1px solid var(--vp-c-border);
+}
+
+.slots-demo__title {
+  margin: 0 0 0.35rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.slots-demo__description {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
+/* A definite height, not min-height: VueFinder sizes itself with height:100%,
+   which only resolves against a parent whose own height is definite. */
+.slots-demo__viewer {
+  height: 440px;
+  background: var(--vp-c-bg);
+}
+
+.slots-demo__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  white-space: nowrap;
+}
+
+.slots-demo__chip--block {
+  width: 100%;
+  padding: 6px 10px;
+}
+
+.slots-demo__loading {
+  padding: 2rem;
+  color: var(--vp-c-text-2);
+  text-align: center;
+}
+
+/* The snippets arrive as VitePress code blocks, which bring their own
+   background and rounding - just host them and drop the outer margins. */
+.slots-demo__code {
+  padding: 0.75rem 1rem;
+  background: var(--vp-c-bg-soft);
+  border-top: 1px solid var(--vp-c-border);
+}
+
+.slots-demo__code :deep(div[class*='language-']) {
+  margin: 0;
+}
+
+.slots-demo__code :deep(div[class*='language-'] + div[class*='language-']) {
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .slots-demo__viewer {
+    height: 360px;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/examples/UIVisibilityDemo.vue
+++ b/docs/.vitepress/theme/components/examples/UIVisibilityDemo.vue
@@ -5,20 +5,33 @@
         <h3 class="ui-visibility-demo__title">UI Visibility Settings</h3>
       </div>
 
+      <!-- The checked state already says visible/hidden, so the chips carry it
+           visually instead of spending a fixed-width word on each one. That
+           keeps all three on a single row. -->
       <div class="ui-visibility-demo__toggles">
-        <label class="ui-visibility-demo__toggle">
-          <input v-model="showMenuBar" type="checkbox" />
-          <span class="ui-visibility-demo__toggle-label">Show Menu Bar</span>
-          <span class="ui-visibility-demo__toggle-status">
-            {{ showMenuBar ? 'Visible' : 'Hidden' }}
-          </span>
+        <label
+          class="ui-visibility-demo__toggle"
+          :class="{ 'ui-visibility-demo__toggle--on': showMenuBar }"
+        >
+          <input v-model="showMenuBar" type="checkbox" class="ui-visibility-demo__input" />
+          <span class="ui-visibility-demo__switch" aria-hidden="true"></span>
+          <span class="ui-visibility-demo__toggle-label">Menu Bar</span>
         </label>
-        <label class="ui-visibility-demo__toggle">
-          <input v-model="showToolbar" type="checkbox" />
-          <span class="ui-visibility-demo__toggle-label">Show Toolbar</span>
-          <span class="ui-visibility-demo__toggle-status">
-            {{ showToolbar ? 'Visible' : 'Hidden' }}
-          </span>
+        <label
+          class="ui-visibility-demo__toggle"
+          :class="{ 'ui-visibility-demo__toggle--on': showToolbar }"
+        >
+          <input v-model="showToolbar" type="checkbox" class="ui-visibility-demo__input" />
+          <span class="ui-visibility-demo__switch" aria-hidden="true"></span>
+          <span class="ui-visibility-demo__toggle-label">Toolbar</span>
+        </label>
+        <label
+          class="ui-visibility-demo__toggle"
+          :class="{ 'ui-visibility-demo__toggle--on': showBreadcrumbBar }"
+        >
+          <input v-model="showBreadcrumbBar" type="checkbox" class="ui-visibility-demo__input" />
+          <span class="ui-visibility-demo__switch" aria-hidden="true"></span>
+          <span class="ui-visibility-demo__toggle-label">Breadcrumb Bar</span>
         </label>
       </div>
     </div>
@@ -34,6 +47,7 @@
             persist: false,
             showMenuBar: showMenuBar,
             showToolbar: showToolbar,
+            showBreadcrumbBar: showBreadcrumbBar,
           }"
         />
         <template #fallback>
@@ -51,6 +65,7 @@ import type { Driver } from 'vuefinder';
 const driver = ref<Driver | null>(null);
 const showMenuBar = ref(true);
 const showToolbar = ref(true);
+const showBreadcrumbBar = ref(true);
 
 onMounted(async () => {
   const { RemoteDriver } = await import('vuefinder');
@@ -91,46 +106,70 @@ onMounted(async () => {
 
 .ui-visibility-demo__toggles {
   display: flex;
-  flex-direction: row;
-  gap: 1rem;
   flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
 }
 
 .ui-visibility-demo__toggle {
-  display: flex;
+  display: inline-flex;
+  flex: none;
+  gap: 0.5rem;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* The native control stays focusable but invisible; the track below is what
+   the user actually sees. */
+.ui-visibility-demo__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
+.ui-visibility-demo__switch {
+  position: relative;
+  flex: none;
+  width: 30px;
+  height: 17px;
+  background: var(--vp-c-gray-soft);
+  border-radius: 3px;
+  transition: background-color 0.2s ease;
+}
+
+.ui-visibility-demo__switch::after {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  content: '';
   background: var(--vp-c-bg);
-  border: 1px solid var(--vp-c-border);
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.15s ease;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 25%);
+  transition: transform 0.2s ease;
 }
 
-.ui-visibility-demo__toggle:hover {
-  background: var(--vp-c-bg-alt);
-  border-color: var(--vp-c-divider);
+.ui-visibility-demo__toggle--on .ui-visibility-demo__switch {
+  background: var(--vp-c-brand-1);
 }
 
-.ui-visibility-demo__toggle input[type='checkbox'] {
-  margin-right: 0.75rem;
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
+.ui-visibility-demo__toggle--on .ui-visibility-demo__switch::after {
+  transform: translateX(13px);
+}
+
+.ui-visibility-demo__input:focus-visible + .ui-visibility-demo__switch {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
 }
 
 .ui-visibility-demo__toggle-label {
-  flex: 1;
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--vp-c-text-1);
-}
-
-.ui-visibility-demo__toggle-status {
-  font-size: 0.75rem;
-  color: var(--vp-c-text-2);
-  font-weight: 500;
 }
 
 .ui-visibility-demo__viewer {
@@ -147,10 +186,6 @@ onMounted(async () => {
 }
 
 @media (max-width: 768px) {
-  .ui-visibility-demo__toggles {
-    flex-direction: column;
-  }
-
   .ui-visibility-demo__viewer {
     min-height: 300px;
   }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -22,6 +22,8 @@ import ExternalSelectDemo from './components/examples/ExternalSelectDemo.vue';
 import StatusBarSelectDemo from './components/examples/StatusBarSelectDemo.vue';
 import ThemeSelectorDemo from './components/examples/ThemeSelectorDemo.vue';
 import UIVisibilityDemo from './components/examples/UIVisibilityDemo.vue';
+import MenuBarSlotsDemo from './components/examples/MenuBarSlotsDemo.vue';
+import CustomMenuBarDemo from './components/examples/CustomMenuBarDemo.vue';
 import ItemSizeConfigurationDemo from './components/examples/ItemSizeConfigurationDemo.vue';
 import NotificationsDemo from './components/examples/NotificationsDemo.vue';
 import ComposableApiDemo from './components/examples/ComposableApiDemo.vue';
@@ -101,6 +103,8 @@ export default {
       app.component('StatusBarSelectDemo', StatusBarSelectDemo);
       app.component('ThemeSelectorDemo', ThemeSelectorDemo);
       app.component('UIVisibilityDemo', UIVisibilityDemo);
+      app.component('MenuBarSlotsDemo', MenuBarSlotsDemo);
+      app.component('CustomMenuBarDemo', CustomMenuBarDemo);
       app.component('ItemSizeConfigurationDemo', ItemSizeConfigurationDemo);
       app.component('NotificationsDemo', NotificationsDemo);
       app.component('ComposableApiDemo', ComposableApiDemo);

--- a/docs/examples/custom-menu-bar.md
+++ b/docs/examples/custom-menu-bar.md
@@ -1,0 +1,125 @@
+---
+outline: deep
+---
+
+# Custom Menu Bar
+
+Replace the menu bar with your own compact toolbar and drop the default toolbar
+and breadcrumb bar, so an embedded file manager costs one row of chrome instead
+of three.
+
+This is the `menu-items` slot put to work. For a tour of every MenuBar slot and
+what each one receives, see [Slots](/guide/slots).
+
+## Live Demo
+
+Toggle **Compact layout** to compare the one-bar result with the default three
+bars. The buttons are the real actions — they open the same modals the default
+menus do.
+
+<ClientOnly>
+  <CustomMenuBarDemo />
+</ClientOnly>
+
+## How It Works
+
+Two pieces do the work together:
+
+1. The `menu-items` slot replaces what is rendered **inside** the menu bar.
+2. `showToolbar` and `showBreadcrumbBar` remove the other two bars, since the
+   custom bar already covers them.
+
+```vue
+<template>
+  <vue-finder
+    id="compact"
+    :driver="driver"
+    :config="{
+      showToolbar: false,
+      showBreadcrumbBar: false,
+    }"
+  >
+    <template #menu-items>
+      <CompactBar />
+    </template>
+  </vue-finder>
+</template>
+```
+
+## The Custom Bar
+
+Rather than reimplementing behaviour, the bar reads the real actions with
+`useMenuItems()` and pairs them with `useBreadcrumbActions()`. Because it is
+rendered inside the VueFinder instance, both composables resolve against that
+instance — exactly as they do in the library's own components.
+
+```vue
+<!-- CompactBar.vue -->
+<script setup>
+import { computed } from 'vue';
+import { useMenuItems, useBreadcrumbActions } from 'vuefinder';
+
+const { menuItems } = useMenuItems();
+// Destructure: `currentPath` is a ref, and only a top-level binding gets
+// unwrapped in the template.
+const { currentPath, goUp, refresh } = useBreadcrumbActions();
+
+// Flatten every menu into an id -> item lookup, then cherry-pick.
+const byId = computed(() => {
+  const map = new Map();
+  for (const menu of menuItems.value) {
+    for (const item of menu.items ?? []) {
+      if (item.id) map.set(item.id, item);
+    }
+  }
+  return map;
+});
+
+const primary = computed(() =>
+  ['new-folder', 'upload', 'rename', 'delete'].map((id) => byId.value.get(id)).filter(Boolean)
+);
+
+const run = (item) => {
+  if (item.enabled && !item.enabled()) return;
+  item.action?.();
+};
+</script>
+
+<template>
+  <div class="bar">
+    <button
+      v-for="item in primary"
+      :key="item.id"
+      :disabled="item.enabled ? !item.enabled() : false"
+      @click="run(item)"
+    >
+      {{ item.label }}
+    </button>
+
+    <button @click="goUp()">↑</button>
+    <button @click="refresh()">⟳</button>
+    <span>{{ currentPath.path }}</span>
+  </div>
+</template>
+```
+
+## Notes
+
+### Respect `enabled` and `hidden`
+
+Menu items carry `enabled()` and `hidden()` predicates that react to the current
+selection — `Rename` only applies to a single item, `Delete` needs a selection at
+all. Honour them so your bar disables and hides the same way the default menus do.
+
+### Item Ids Are the Contract
+
+Cherry-picking by id (`new-folder`, `upload`, `rename`, `delete`, `grid-view`,
+`list-view`, `fullscreen`) keeps the bar stable while letting VueFinder own the
+behaviour. An id that does not exist is simply skipped by the `filter(Boolean)`
+above, so a missing action degrades quietly rather than throwing.
+
+### Hiding vs. Replacing
+
+A slot replaces the *contents* of a bar; it never hides the bar itself. Removing
+a bar is what the visibility options are for — see
+[UI Visibility](/examples/ui-visibility).

--- a/docs/examples/ui-visibility.md
+++ b/docs/examples/ui-visibility.md
@@ -4,7 +4,7 @@ outline: deep
 
 # UI Visibility
 
-Control the visibility of menu bar and toolbar components in VueFinder.
+Control the visibility of the menu bar, toolbar and breadcrumb bar in VueFinder.
 
 ## Live Demo
 
@@ -42,7 +42,21 @@ Control the visibility of menu bar and toolbar components in VueFinder.
 </template>
 ```
 
-### Hide Both
+### Hide Breadcrumb Bar
+
+```vue
+<template>
+  <vue-finder
+    id="no-breadcrumb"
+    :driver="driver"
+    :config="{
+      showBreadcrumbBar: false,
+    }"
+  />
+</template>
+```
+
+### Hide All Three
 
 ```vue
 <template>
@@ -52,6 +66,7 @@ Control the visibility of menu bar and toolbar components in VueFinder.
     :config="{
       showMenuBar: false,
       showToolbar: false,
+      showBreadcrumbBar: false,
     }"
   />
 </template>
@@ -69,17 +84,21 @@ These settings are **non-persistent**, which means:
 
 ### Default Values
 
-Both `showMenuBar` and `showToolbar` default to `true`, so the menu bar and toolbar are visible by default unless explicitly set to `false`.
+`showMenuBar`, `showToolbar` and `showBreadcrumbBar` all default to `true`, so the menu bar, toolbar and breadcrumb bar are visible unless explicitly set to `false`.
 
 ### Reactivity
 
-The config prop is reactive, so changes to `showMenuBar` or `showToolbar` will immediately update the UI. You can use Vue's reactive refs or computed properties to control these values dynamically.
+The config prop is reactive, so changing any of these values immediately updates the UI. You can use Vue's reactive refs or computed properties to control them dynamically.
+
+### Hiding vs. Replacing
+
+These options remove a bar entirely. To keep a bar but change what it contains, use the slots instead — see [Slots](/guide/slots) for `menubar-start`, `menu-items`, `menubar-end`, `toolbar-items` and `breadcrumb-actions`.
 
 ## Use Cases
 
 ### Minimal UI Mode
 
-Create a clean, minimal interface by hiding both components:
+Create a clean, minimal interface by hiding every bar, leaving just the file list:
 
 ```vue
 <template>
@@ -89,6 +108,7 @@ Create a clean, minimal interface by hiding both components:
     :config="{
       showMenuBar: false,
       showToolbar: false,
+      showBreadcrumbBar: false,
     }"
   />
 </template>

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -112,6 +112,78 @@ If the condition doesn't match, the default icon will be shown automatically.
 
 Add content around the default menu bar, or replace it entirely.
 
+#### Live Demo
+
+Each tab below is the same VueFinder instance with a different combination of
+these slots — from the untouched default to every bar replaced individually.
+
+<ClientOnly>
+<MenuBarSlotsDemo>
+<template #code-default>
+
+```vue
+<vue-finder :driver="driver" />
+```
+
+</template>
+<template #code-around>
+
+```vue
+<vue-finder :driver="driver">
+  <template #menubar-start>
+    <span class="chip">🗂️ My App</span>
+  </template>
+
+  <template #menubar-end="{ menuItems }">
+    <span class="chip">{{ menuItems.length }} menus</span>
+  </template>
+</vue-finder>
+```
+
+</template>
+<template #code-replace>
+
+```vue
+<vue-finder :driver="driver">
+  <template #menu-items>
+    <CombinedBar />
+  </template>
+</vue-finder>
+```
+
+```vue
+<!-- CombinedBar.vue -->
+<script setup>
+import { useMenuItems, useBreadcrumbActions } from 'vuefinder';
+
+const { menuItems } = useMenuItems();
+const breadcrumb = useBreadcrumbActions();
+</script>
+```
+
+</template>
+<template #code-each>
+
+```vue
+<vue-finder :driver="driver">
+  <template #menu-items="{ menuItems }">
+    <div class="chip">Custom MenuBar ({{ menuItems.length }})</div>
+  </template>
+
+  <template #toolbar-items>
+    <div class="chip">Custom Toolbar</div>
+  </template>
+
+  <template #breadcrumb-actions>
+    <div class="chip">Custom Breadcrumb Actions</div>
+  </template>
+</vue-finder>
+```
+
+</template>
+</MenuBarSlotsDemo>
+</ClientOnly>
+
 **Scoped Props (all three):**
 
 - `menuItems` - `MenuItem[]` - the default File/Edit/View/Go/Help structure

--- a/examples/examples/MenuBarCombinedBar.vue
+++ b/examples/examples/MenuBarCombinedBar.vue
@@ -9,7 +9,9 @@ import { useMenuItems, useBreadcrumbActions } from '../../src';
 import type { MenuItem } from '../../src';
 
 const { menuItems } = useMenuItems();
-const breadcrumb = useBreadcrumbActions();
+// Destructured so `currentPath` stays a top-level binding and the template
+// unwraps it; `breadcrumb.currentPath.path` would read through the ref object.
+const { currentPath, goUp, refresh, toggleTreeView, copyCurrentPath } = useBreadcrumbActions();
 
 function flatActionable(menu: MenuItem | undefined): MenuItem[] {
   if (!menu?.items) return [];
@@ -36,7 +38,7 @@ function run(item: MenuItem) {
 <template>
   <div class="combined-bar">
     <div class="combined-bar__group combined-bar__group--path">
-      <span class="combined-bar__path">{{ breadcrumb.currentPath.path }}</span>
+      <span class="combined-bar__path">{{ currentPath.path }}</span>
     </div>
 
     <div class="combined-bar__group">
@@ -81,10 +83,10 @@ function run(item: MenuItem) {
 
     <div class="combined-bar__group">
       <span class="combined-bar__group-label">Breadcrumb actions</span>
-      <button class="combined-bar__btn" @click="breadcrumb.refresh()">Refresh</button>
-      <button class="combined-bar__btn" @click="breadcrumb.goUp()">Go Up</button>
-      <button class="combined-bar__btn" @click="breadcrumb.toggleTreeView()">Toggle Tree</button>
-      <button class="combined-bar__btn" @click="breadcrumb.copyCurrentPath()">Copy Path</button>
+      <button class="combined-bar__btn" @click="refresh()">Refresh</button>
+      <button class="combined-bar__btn" @click="goUp()">Go Up</button>
+      <button class="combined-bar__btn" @click="toggleTreeView()">Toggle Tree</button>
+      <button class="combined-bar__btn" @click="copyCurrentPath()">Copy Path</button>
     </div>
   </div>
 </template>

--- a/examples/examples/MenuBarCustomizationExample.vue
+++ b/examples/examples/MenuBarCustomizationExample.vue
@@ -180,9 +180,13 @@ const computedConfig = computed(() => ({
   cursor: pointer;
 }
 
+/* A definite height rather than `flex: 1` + `min-height`: with `flex-basis: 0`
+   the viewer's height is indefinite, so VueFinder's own `height: 100%` cannot
+   resolve against it and the box keeps its size while the file manager shrinks
+   to its content, leaving a bare white strip underneath. */
 .menubar-customization-example__viewer {
-  flex: 1;
-  min-height: 480px;
+  flex: none;
+  height: 480px;
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 12px;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:build": "npm run build && vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
   "homepage": "https://github.com/n1crack/vuefinder#readme",

--- a/src/__tests__/scanFiles.spec.ts
+++ b/src/__tests__/scanFiles.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { entryRelativePath, scanFiles } from '../utils/scanFiles';
+
+const fileEntry = (fullPath: string) => {
+  const name = fullPath.split('/').pop() as string;
+  return {
+    isFile: true,
+    isDirectory: false,
+    fullPath,
+    file: (resolve: (file: File) => void) => resolve(new File(['x'], name)),
+  };
+};
+
+/** Mimics readEntries(), which yields at most `chunkSize` entries per call. */
+const dirEntry = (fullPath: string, children: any[], chunkSize = 100) => {
+  let offset = 0;
+  return {
+    isFile: false,
+    isDirectory: true,
+    fullPath,
+    createReader: () => ({
+      readEntries: (resolve: (entries: any[]) => void) => {
+        const chunk = children.slice(offset, offset + chunkSize);
+        offset += chunk.length;
+        resolve(chunk);
+      },
+    }),
+  };
+};
+
+const collect = async (entry: any) => {
+  const names: string[] = [];
+  await scanFiles((scanned: any, file: File) => {
+    names.push(entryRelativePath(scanned, file));
+  }, entry);
+  return names;
+};
+
+describe('scanFiles', () => {
+  it('preserves the nested folder structure', async () => {
+    const tree = dirEntry('/my-folder', [
+      fileEntry('/my-folder/file1.txt'),
+      dirEntry('/my-folder/subfolder', [fileEntry('/my-folder/subfolder/file2.txt')]),
+    ]);
+
+    expect(await collect(tree)).toEqual([
+      'my-folder/file1.txt',
+      'my-folder/subfolder/file2.txt',
+    ]);
+  });
+
+  it('reads directories with more than 100 entries', async () => {
+    const children = Array.from({ length: 250 }, (_, i) => fileEntry(`/big/file${i}.txt`));
+
+    expect(await collect(dirEntry('/big', children))).toHaveLength(250);
+  });
+
+  it('skips files that cannot be read instead of hanging', async () => {
+    const unreadable = {
+      isFile: true,
+      isDirectory: false,
+      fullPath: '/my-folder/locked.txt',
+      file: (_resolve: unknown, reject: () => void) => reject(),
+    };
+    const tree = dirEntry('/my-folder', [unreadable, fileEntry('/my-folder/file1.txt')]);
+
+    expect(await collect(tree)).toEqual(['my-folder/file1.txt']);
+  });
+
+  it('ignores a missing entry', async () => {
+    expect(await collect(null)).toEqual([]);
+  });
+});
+
+describe('entryRelativePath', () => {
+  it('strips the leading slash', () => {
+    expect(entryRelativePath({ fullPath: '/my-folder/file.txt' }, new File([], 'file.txt'))).toBe(
+      'my-folder/file.txt'
+    );
+  });
+
+  it('falls back to the file name when the entry has no path', () => {
+    expect(entryRelativePath({}, new File([], 'file.txt'))).toBe('file.txt');
+  });
+});

--- a/src/components/VueFinderView.vue
+++ b/src/components/VueFinderView.vue
@@ -202,7 +202,7 @@ const handleExternalDrop = async (e: DragEvent) => {
     setTimeout(() => {
       app.emitter.emit(
         'vf-external-files-dropped',
-        droppedFiles.map((f) => f.file)
+        droppedFiles.map((f) => ({ file: f.file, path: f.path }))
       );
     }, 100);
   }

--- a/src/components/modals/ModalUpload.vue
+++ b/src/components/modals/ModalUpload.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, nextTick, ref } from 'vue';
-import type { QueueEntry } from '../../composables/useUpload';
+import type { ExternalUploadFile, QueueEntry } from '../../composables/useUpload';
 import { useStore } from '@nanostores/vue';
 import Message from '../../components/Message.vue';
 import ModalHeader from '../../components/modals/ModalHeader.vue';
@@ -127,7 +127,7 @@ const upload = () => {
 // Dışarıdan gelen dosyaları dinle
 onMounted(() => {
   app.emitter.on('vf-external-files-dropped', (event: unknown) => {
-    addExternalFiles(event as File[]);
+    addExternalFiles(event as Array<File | ExternalUploadFile>);
   });
 });
 

--- a/src/composables/useExternalDragDrop.ts
+++ b/src/composables/useExternalDragDrop.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { scanFiles } from '../utils/scanFiles';
+import { entryRelativePath, scanFiles } from '../utils/scanFiles';
 
 export interface ExternalFile {
   name: string;
@@ -7,6 +7,8 @@ export interface ExternalFile {
   type: string;
   lastModified: Date;
   file: File;
+  /** Path relative to the drop, e.g. "my-folder/sub/file.txt". */
+  path: string;
 }
 
 export function useExternalDragDrop() {
@@ -73,6 +75,7 @@ export function useExternalDragDrop() {
                 type: file.type,
                 lastModified: new Date(file.lastModified),
                 file: file,
+                path: entryRelativePath(entry, file),
               });
             }, getAsEntry);
           } else {
@@ -85,6 +88,7 @@ export function useExternalDragDrop() {
                 type: file.type,
                 lastModified: new Date(file.lastModified),
                 file: file,
+                path: file.name,
               });
             }
           }

--- a/src/composables/useUpload.ts
+++ b/src/composables/useUpload.ts
@@ -3,7 +3,7 @@ import { useApp } from '../composables/useApp';
 import Uppy from '@uppy/core';
 import { parse } from '../utils/filesize';
 import { useStore } from '@nanostores/vue';
-import { scanFiles } from '../utils/scanFiles';
+import { entryRelativePath, scanFiles } from '../utils/scanFiles';
 import type { CurrentPathState } from '../stores/files';
 import type { StoreValue } from 'nanostores';
 
@@ -26,6 +26,15 @@ export interface QueueEntry {
   originalFile: File;
 }
 
+/**
+ * File coming from outside the upload modal, optionally carrying the path it
+ * had relative to the dropped folder.
+ */
+export interface ExternalUploadFile {
+  file: File;
+  path?: string;
+}
+
 export interface UseUploadReturn {
   container: Ref<HTMLElement | null>;
   internalFileInput: Ref<HTMLInputElement | null>;
@@ -45,7 +54,7 @@ export interface UseUploadReturn {
   close: () => void;
   getClassNameForEntry: (entry: QueueEntry) => string;
   getIconForEntry: (entry: QueueEntry) => string;
-  addExternalFiles: (files: File[]) => void;
+  addExternalFiles: (files: Array<File | ExternalUploadFile>) => void;
   renameEntry: (entry: QueueEntry, newName: string) => Promise<void>;
 }
 
@@ -97,7 +106,6 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
     hasFilesInDropArea.value = false;
 
     // Always accept files when upload modal is open
-    const trimFileName = /^[/\\](.+)/;
     const dt = ev.dataTransfer;
     if (!dt) return;
 
@@ -108,8 +116,7 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
           const getAsEntry = (item as any).webkitGetAsEntry?.();
           if (getAsEntry) {
             scanFiles((entry: any, file: File) => {
-              const matched = trimFileName.exec((entry?.fullPath as string) || '');
-              addFile(file, matched ? matched[1] : file.name);
+              addFile(file, entryRelativePath(entry, file));
             }, getAsEntry);
           } else {
             const f = item.getAsFile?.();
@@ -193,9 +200,13 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
     }
   };
 
-  const addExternalFiles = (files: File[]) => {
-    files.forEach((file) => {
-      addFile(file);
+  const addExternalFiles = (files: Array<File | ExternalUploadFile>) => {
+    files.forEach((item) => {
+      if ('file' in item) {
+        addFile(item.file, item.path || item.file.name);
+      } else {
+        addFile(item);
+      }
     });
   };
 
@@ -397,7 +408,9 @@ export default function useUpload(customUploader?: any): UseUploadReturn {
       const target = evt.target as HTMLInputElement;
       const files = target.files;
       if (!files) return;
-      for (const file of files) addFile(file);
+      // The folder picker fills webkitRelativePath ("my-folder/sub/file.txt");
+      // the plain file picker leaves it empty.
+      for (const file of files) addFile(file, file.webkitRelativePath || file.name);
       target.value = '';
     };
 

--- a/src/utils/scanFiles.ts
+++ b/src/utils/scanFiles.ts
@@ -9,19 +9,34 @@ export const scanFiles = async (
   if (!item) return;
 
   if (item.isFile) {
-    const file = await new Promise<File>((resolve) => {
-      item.file(resolve);
+    const file = await new Promise<File | null>((resolve) => {
+      item.file(resolve, () => resolve(null));
     });
-    resultCallback(item, file);
+    if (file) resultCallback(item, file);
   }
 
   if (item.isDirectory) {
     const reader = item.createReader();
-    const entries = await new Promise<any[]>((resolve) => {
-      reader.readEntries(resolve);
-    });
-    for (const entry of entries) {
-      await scanFiles(resultCallback, entry);
+    // readEntries() yields at most 100 entries per call, so it has to be called
+    // repeatedly until it returns an empty array to read the whole directory.
+    for (;;) {
+      const entries = await new Promise<any[]>((resolve) => {
+        reader.readEntries(resolve, () => resolve([]));
+      });
+      if (!entries.length) break;
+      for (const entry of entries) {
+        await scanFiles(resultCallback, entry);
+      }
     }
   }
+};
+
+/**
+ * Relative path of a scanned entry, without the leading slash
+ * (e.g. "/my-folder/sub/file.txt" -> "my-folder/sub/file.txt").
+ * Falls back to the file name when the entry carries no path.
+ */
+export const entryRelativePath = (entry: any, file: File): string => {
+  const matched = /^[/\\](.+)/.exec((entry?.fullPath as string) || '');
+  return matched?.[1] ?? file.name;
 };


### PR DESCRIPTION
## Summary

Three pieces of work: a folder-upload bug fix, live documentation for the MenuBar slots, and the example/docs cleanups they surfaced.

## Folder upload keeps its structure (#207)

Folder uploads only preserved the directory structure when the folder was dropped onto the open upload modal. The two other entry points flattened it:

- Dropping a folder onto the file manager scanned entries but stored only `file.name`, discarding `entry.fullPath` before the files reached the modal.
- The "Select Folders" picker ignored `webkitRelativePath`.

Both now pass the relative path to `addFile()`, which uppy already sends as the upload name, so nested files land in the right folder. The leading-slash trimming used by the modal drop path moved into a shared `entryRelativePath()` helper.

`scanFiles()` also dropped entries in large folders: `readEntries()` returns at most 100 entries per call and has to be called until it yields an empty array. Unreadable files are now skipped instead of leaving the scan pending forever. Covered by new unit tests.

No backend change was needed — `UploadAction` reads the POST `name` field rather than the basenamed `$_FILES` name, and Flysystem creates the intermediate directories.

## MenuBar slot demos

The slots guide documented every MenuBar slot but had no live demo, while the UI visibility example demoed two of the three visibility options. Both gaps are filled along their natural seam rather than duplicating one demo in two places:

- `guide/slots` gets a four-tab demo: the untouched default, `menubar-start`/`menubar-end`, a `menu-items` replacement, and every bar slotted individually. Snippets are passed in as markdown fences so VitePress highlights them with Shiki in both themes.
- `examples/custom-menu-bar` is the practical counterpart — one compact bar replacing three default ones, driven by the real actions.
- `examples/ui-visibility` picks up the missing `showBreadcrumbBar`, and its toggles became switches that hold a single row in every state.

## Fixes found along the way

- `docs:build` now builds the library first. It renders against `dist/`, which is only rebuilt at release time, so the demos would otherwise ship against a dist predating the slots they demonstrate.
- The combined bars read `breadcrumb.currentPath.path`, which rendered empty: `currentPath` is a ref and only a top-level binding is unwrapped in a template.
- The MenuBar customization example left a bare white strip under the file manager — its viewer was a flex item with `flex: 1`, so VueFinder's `height: 100%` had no definite parent height to resolve against.

## Tests

`vitest`: 6 files, 55 tests passed. `type-check`, `eslint`, `prettier` and `docs:build` all clean.