### PR TITLE
4.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vuefinder",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuefinder",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefinder",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "A sleek, developer-friendly file manager for Vue — organize, preview, and manage files with ease.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the 4.7.0 release.

Since 4.6.0:

**New API**
- `useMenuItems()` and `useBreadcrumbActions()` are exported, so a custom bar can drive the real actions
- MenuBar slots: `menubar-start`, `menu-items`, `menubar-end`, plus `toolbar-items` and `breadcrumb-actions`
- `showBreadcrumbBar` config option

**Fixes**
- Folder uploads keep their directory structure in every entry point, and `scanFiles()` no longer stops at the first 100 entries (#207)
- External drag and drop of more than one file
- Upload state is set on upload start, so the cancel button appears (#197)
- Image editor save target at the storage root (#202)
- `notificationsEnabled` respects the prop over the persisted value (#194)
- Caret visible in dark mode

**Docs**
- Live demos for the MenuBar slots in the slots guide and a Custom Menu Bar example
- UI Visibility covers `showBreadcrumbBar`