### PR TITLE
chore(deps): bump GitHub Actions to v7, drop stub types package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    ignore:
+      # TypeScript 7 ships only the native binary and `unstable/*` APIs, with no
+      # classic compiler API, so vue-tsc cannot run against it. Both type-check
+      # and type-gen depend on vue-tsc, so stay on 5.x until vue-language-tools
+      # supports tsgo.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       # Keep the noise down: batch routine updates into single PRs.
       dev-dependencies:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       CYPRESS_INSTALL_BINARY: '0'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       CYPRESS_INSTALL_BINARY: '0'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@tsconfig/node22": "^22.0.2",
         "@types/jsdom": "^30.0.0",
         "@types/node": "^26.2.0",
-        "@types/overlayscrollbars": "^1.12.5",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitejs/plugin-vue-jsx": "^5.1.1",
         "@vue/devtools-api": "^8.0.3",
@@ -2687,13 +2686,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/overlayscrollbars": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/@types/overlayscrollbars/-/overlayscrollbars-1.12.5.tgz",
-      "integrity": "sha512-1yMmgFrq1DQ3sCHyb3DNfXnE0dB463MjG47ugX3cyade3sOt3U8Fjxk/Com0JJguTLPtw766TSDaO4NC65Wgkw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/papaparse": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "@tsconfig/node22": "^22.0.2",
     "@types/jsdom": "^30.0.0",
     "@types/node": "^26.2.0",
-    "@types/overlayscrollbars": "^1.12.5",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitejs/plugin-vue-jsx": "^5.1.1",
     "@vue/devtools-api": "^8.0.3",


### PR DESCRIPTION
Handles the four open Dependabot PRs. They cannot be merged through `gh` because
the token lacks the `workflow` scope, so the changes are applied here instead.

| PR | Action | Why |
|----|--------|-----|
| #223 `actions/checkout` 5 → 7 | applied | CI passed on the Dependabot branch |
| #224 `actions/setup-node` 5 → 7 | applied | CI passed on the Dependabot branch |
| #225 `typescript` 5.9.3 → 7.0.2 | **rejected** | see below |
| #226 `@types/overlayscrollbars` 1.12.5 → 2.0.0 | **removed instead** | see below |

### #225 — TypeScript 7 rejected

TypeScript 7's npm package ships only the native binary and `unstable/*` APIs; it
exports no classic compiler API. `vue-tsc` fails immediately against it:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not
defined by "exports" in node_modules/typescript/package.json
```

Both `type-check` and `type-gen` (which emits `dist/types`) run through `vue-tsc`,
so merging this would break the build and ship a package with no type definitions.
Dependabot is now configured to skip TypeScript majors until vue-language-tools
supports tsgo.

### #226 — package removed rather than bumped

`@types/overlayscrollbars@2.0.0` is a deprecated stub:

> This is a stub types definition. overlayscrollbars provides its own type
> definitions, so you do not need this installed.

`overlayscrollbars` v2 declares `types: types/overlayscrollbars.d.ts`, so the
dependency is dead weight. It is dropped instead of bumped; `type-check` still
passes.

## Verification

`format:check`, `lint`, `type-check`, `vitest run` and `build` all pass locally.

No version bump — these are workflow and devDependency changes only, so the
published 4.7.4 package is unaffected.