### PR TITLE
chore(deps): uppy v6, drop unused @uppy/vue, 4.7.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
         update-types:
           - 'version-update:semver-major'
     groups:
+      # @uppy/* packages peer-depend on a matching @uppy/core major, so a
+      # single-package major bump always fails to resolve. Ship them together.
+      uppy:
+        patterns:
+          - '@uppy/*'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
       # Keep the noise down: batch routine updates into single PRs.
       dev-dependencies:
         dependency-type: 'development'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vuefinder",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuefinder",
-      "version": "4.7.4",
+      "version": "4.7.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
@@ -22,10 +22,9 @@
         "@nanostores/vue": "^1.0.1",
         "@tanstack/vue-query": "^5.90.2",
         "@types/papaparse": "^5.5.2",
-        "@uppy/core": "^5.0.2",
-        "@uppy/locales": "^5.0.1",
-        "@uppy/vue": "^3.1.0",
-        "@uppy/xhr-upload": "^5.0.1",
+        "@uppy/core": "^6.0.0",
+        "@uppy/locales": "^5.2.0",
+        "@uppy/xhr-upload": "^6.0.0",
         "@viselect/vanilla": "^3.9.0",
         "codemirror": "^6.0.2",
         "mitt": "^3.0.1",
@@ -2616,10 +2615,13 @@
       }
     },
     "node_modules/@transloadit/prettier-bytes": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@transloadit/prettier-bytes/-/prettier-bytes-0.3.5.tgz",
-      "integrity": "sha512-xF4A3d/ZyX2LJWeQZREZQw+qFX4TGQ8bGVP97OLRt6sPO6T0TNHBFTuRHOJh7RNmYOBmQ9MHxpolD9bXihpuVA==",
-      "license": "MIT"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@transloadit/prettier-bytes/-/prettier-bytes-2.0.0.tgz",
+      "integrity": "sha512-GYzxSL3y9XlhwamBLkHT1y2jFrRsHkZZ1jNctn8NeMNyTtIbMK1Qf0f1koHkDdW+MwOUowCmpm8zP6ZpQ36G5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@tsconfig/node22": {
       "version": "22.0.6",
@@ -2818,84 +2820,7 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@uppy/companion-client": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-5.1.1.tgz",
-      "integrity": "sha512-DzrOWTbIZHvtgAFXBMYHk2wD27NjpBSVhY2tEiEIUhPd2CxbFRZjHM/N3HOt3VwZEAP471QWFLlJRWPcIY3A2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@uppy/utils": "^7.1.1",
-        "namespace-emitter": "^2.0.1",
-        "p-retry": "^6.1.0"
-      },
-      "peerDependencies": {
-        "@uppy/core": "^5.1.1"
-      }
-    },
-    "node_modules/@uppy/components": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/components/-/components-1.2.0.tgz",
-      "integrity": "sha512-rtIr+77Rw/q5Vw++xazF1dCg2d4A4zT9CV+ZyN8Rsx8xiIr2CxCR4TaHHBy+WeC0b7Mk6yNuJ0wUa34tFJ6pKg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "dequal": "^2.0.3",
-        "preact": "^10.26.10",
-        "pretty-bytes": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@uppy/core": "^5.2.0",
-        "@uppy/image-editor": "^4.2.0",
-        "@uppy/screen-capture": "^5.1.0",
-        "@uppy/webcam": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@uppy/image-editor": {
-          "optional": true
-        },
-        "@uppy/screen-capture": {
-          "optional": true
-        },
-        "@uppy/webcam": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@uppy/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-uvfNyz4cnaplt7LYJmEZHuqOuav0tKp4a9WKJIaH6iIj7XiqYvS2J5SEByexAlUFlzefOAyjzj4Ja2dd/8aMrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@transloadit/prettier-bytes": "^0.3.4",
-        "@uppy/store-default": "^5.0.0",
-        "@uppy/utils": "^7.1.4",
-        "lodash": "^4.17.21",
-        "mime-match": "^1.0.2",
-        "namespace-emitter": "^2.0.1",
-        "nanoid": "^5.0.9",
-        "preact": "^10.5.13"
-      }
-    },
-    "node_modules/@uppy/locales": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/locales/-/locales-5.2.0.tgz",
-      "integrity": "sha512-nW+jrrljbVVBRmYhfUBn5eU7rQV27/NkgJyo7VB+G3OHCaG4EhWoGcGrF5qu/apHkaQx+3a+jKwCueAuzff6Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@uppy/core": "^6.0.0"
-      }
-    },
-    "node_modules/@uppy/locales/node_modules/@transloadit/prettier-bytes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@transloadit/prettier-bytes/-/prettier-bytes-2.0.0.tgz",
-      "integrity": "sha512-GYzxSL3y9XlhwamBLkHT1y2jFrRsHkZZ1jNctn8NeMNyTtIbMK1Qf0f1koHkDdW+MwOUowCmpm8zP6ZpQ36G5w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@uppy/locales/node_modules/@uppy/core": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@uppy/core/-/core-6.0.0.tgz",
       "integrity": "sha512-qaNqf4t2nxnbFFLSVmLr7Jw9TaA4fzvl8paR/ggwiOo5XFgAfbCFzjDzP8l2r5UzR6cCt3wS95QWvrm82UGZ+g==",
@@ -2912,66 +2837,22 @@
         "preact": "^10.29.2"
       }
     },
-    "node_modules/@uppy/store-default": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-5.0.0.tgz",
-      "integrity": "sha512-hQtCSQ1yGiaval/wVYUWquYGDJ+bpQ7e4FhUUAsRQz1x1K+o7NBtjfp63O9I4Ks1WRoKunpkarZ+as09l02cPw==",
-      "license": "MIT"
-    },
-    "node_modules/@uppy/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-6lC246qszMv6bTyl/+QyHwrudgeguWkA94ME1wHn+a6uRAvmtAEaUManIfGqTJfoKvWAiCJqdJPl5xRJjhAloQ==",
+    "node_modules/@uppy/locales": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@uppy/locales/-/locales-5.2.0.tgz",
+      "integrity": "sha512-nW+jrrljbVVBRmYhfUBn5eU7rQV27/NkgJyo7VB+G3OHCaG4EhWoGcGrF5qu/apHkaQx+3a+jKwCueAuzff6Fw==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.23",
-        "preact": "^10.26.10"
-      }
-    },
-    "node_modules/@uppy/vue": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/vue/-/vue-3.2.0.tgz",
-      "integrity": "sha512-BZiyUZxpadf3uUp8YzgwRZTIde/m9Ne4ILFygJg7ilFq/Qfb1pBVspG9FJoG23RbOiRuxd4JixwFh0gaFdfL+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@uppy/components": "^1.2.0",
-        "preact": "^10.26.10",
-        "shallow-equal": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@uppy/core": "^5.2.0",
-        "@uppy/dashboard": "^5.1.1",
-        "@uppy/screen-capture": "^5.1.0",
-        "@uppy/status-bar": "^5.1.0",
-        "@uppy/webcam": "^5.1.0",
-        "vue": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@uppy/dashboard": {
-          "optional": true
-        },
-        "@uppy/screen-capture": {
-          "optional": true
-        },
-        "@uppy/status-bar": {
-          "optional": true
-        },
-        "@uppy/webcam": {
-          "optional": true
-        }
+        "@uppy/core": "^6.0.0"
       }
     },
     "node_modules/@uppy/xhr-upload": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-5.2.0.tgz",
-      "integrity": "sha512-3LV/X5Of6BINnKplP+CwUJ0a4/7cRFfzxwGyXnW+uCrNQHoo09dttcz3begWHejGvzenQHuUnMO3Fxyc71Pryg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-6.0.0.tgz",
+      "integrity": "sha512-r1EV5LUoMCQjeQVkc+qupCXA5wn8vRV7m3iB5K7z/4nkSj7lEt4Hk0fkudeQ/h4sF9wi3SqAM1x2Syhbt6Ar8A==",
       "license": "MIT",
-      "dependencies": {
-        "@uppy/companion-client": "^5.1.1",
-        "@uppy/utils": "^7.2.0"
-      },
       "peerDependencies": {
-        "@uppy/core": "^5.2.0"
+        "@uppy/core": "^6.0.0"
       }
     },
     "node_modules/@viselect/vanilla": {
@@ -4190,15 +4071,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -4647,6 +4519,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7737,18 +7610,6 @@
         }
       }
     },
-    "node_modules/pretty-bytes": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8182,12 +8043,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/shallow-equal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
-      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefinder",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "description": "A sleek, developer-friendly file manager for Vue — organize, preview, and manage files with ease.",
   "type": "module",
   "engines": {
@@ -103,10 +103,9 @@
     "@nanostores/vue": "^1.0.1",
     "@tanstack/vue-query": "^5.90.2",
     "@types/papaparse": "^5.5.2",
-    "@uppy/core": "^5.0.2",
-    "@uppy/locales": "^5.0.1",
-    "@uppy/vue": "^3.1.0",
-    "@uppy/xhr-upload": "^5.0.1",
+    "@uppy/core": "^6.0.0",
+    "@uppy/locales": "^5.2.0",
+    "@uppy/xhr-upload": "^6.0.0",
     "@viselect/vanilla": "^3.9.0",
     "codemirror": "^6.0.2",
     "mitt": "^3.0.1",


### PR DESCRIPTION
Cleans up the three stuck Dependabot uppy PRs (#231, #232, #233 — all closed as superseded).

## Changes
- **`@uppy/core` 5.2.0 → ^6.0.0** and **`@uppy/xhr-upload` 5.2.0 → ^6.0.0**, bumped together. `@uppy/xhr-upload@6` peer-depends on `@uppy/core@^6`, so Dependabot's per-package PRs each failed CI with ERESOLVE.
- **`@uppy/locales` → ^5.2.0**, which now depends on core 6.
- **Removed `@uppy/vue`.** It was declared as a dependency but never imported anywhere in `src/`. Its v4 peers require `@uppy/dashboard`, `@uppy/webcam`, `@uppy/status-bar` and `@uppy/screen-capture`, none of which this project uses.
- **`dependabot.yml`:** added an `uppy` group matching `@uppy/*` across major/minor/patch, so future uppy majors arrive as one resolvable PR instead of N conflicting ones.
- Version bumped to **4.7.5**.

## Notes on uppy 6
Nothing in the v6 breaking-change list touches this codebase — the removals are `@uppy/utils`/`@uppy/store-default`/`@uppy/companion-client`/`@uppy/provider-views` (merged into core subpaths), the Companion websocket token change, and `isTouchDevice`. VueFinder only uses `@uppy/core` and `@uppy/xhr-upload` directly.

## Verification
- `npm run lint` — clean
- `npm run type-check` — clean
- `npm run build` — succeeds
- `vitest run` — 55 tests across 6 files passing